### PR TITLE
Support freeform text @see tag

### DIFF
--- a/sphinx_js/doclets.py
+++ b/sphinx_js/doclets.py
@@ -65,6 +65,9 @@ def gather_doclets(app):
             segments = doclet_full_path(d, root_for_relative_paths, longname_field='memberof')
             app._sphinxjs_doclets_by_class[tuple(segments)].append(d)
 
+    # Process @see tags
+    process_see(doclets, app._sphinxjs_doclets_by_path)
+
 
 def program_name_on_this_platform(program):
     """Return the name of the executable file on the current platform, given a
@@ -139,6 +142,23 @@ def analyzer_for(language):
     except KeyError:
         raise SphinxError('Unsupported value of js_language in config: %s' % language)
 
+def process_see(doclets, suffix_tree):
+    """Process @see tags for all doclets."""
+    for doclet in doclets:
+        if 'see' in doclet:
+            see = doclet['see']
+            process_see_list(see, suffix_tree)
+
+def process_see_list(see, suffix_tree):
+    """Process a list of @see tag values.
+
+    Leaves any value with a space as freeform text.
+    Translates other values into RST crossreferences.
+    """
+    for i, item in enumerate(see):
+        if ' ' not in item:
+            item = ':any:`%s`' % item
+            see[i] = item
 
 def root_or_fallback(root_for_relative_paths, abs_source_paths):
     """Return the path that relative JS entity paths in the docs are relative to.

--- a/sphinx_js/doclets.py
+++ b/sphinx_js/doclets.py
@@ -161,7 +161,7 @@ def process_see_list(see):
         if ' ' in item:
             item = process_see_item_text(item)
         else:
-            item = ':any:`%s`' % item
+            item = ':any:`%s`' % item.strip()
         see[i] = item
 
 

--- a/sphinx_js/doclets.py
+++ b/sphinx_js/doclets.py
@@ -142,12 +142,14 @@ def analyzer_for(language):
     except KeyError:
         raise SphinxError('Unsupported value of js_language in config: %s' % language)
 
+
 def process_see(doclets):
     """Process @see tags for all doclets."""
     for doclet in doclets:
         if 'see' in doclet:
             see = doclet['see']
             process_see_list(see)
+
 
 def process_see_list(see):
     """Process a list of @see tag values.
@@ -159,6 +161,7 @@ def process_see_list(see):
         if ' ' not in item:
             item = ':any:`%s`' % item
             see[i] = item
+
 
 def root_or_fallback(root_for_relative_paths, abs_source_paths):
     """Return the path that relative JS entity paths in the docs are relative to.

--- a/sphinx_js/doclets.py
+++ b/sphinx_js/doclets.py
@@ -66,7 +66,7 @@ def gather_doclets(app):
             app._sphinxjs_doclets_by_class[tuple(segments)].append(d)
 
     # Process @see tags
-    process_see(doclets, app._sphinxjs_doclets_by_path)
+    process_see(doclets)
 
 
 def program_name_on_this_platform(program):
@@ -142,14 +142,14 @@ def analyzer_for(language):
     except KeyError:
         raise SphinxError('Unsupported value of js_language in config: %s' % language)
 
-def process_see(doclets, suffix_tree):
+def process_see(doclets):
     """Process @see tags for all doclets."""
     for doclet in doclets:
         if 'see' in doclet:
             see = doclet['see']
-            process_see_list(see, suffix_tree)
+            process_see_list(see)
 
-def process_see_list(see, suffix_tree):
+def process_see_list(see):
     """Process a list of @see tag values.
 
     Leaves any value with a space as freeform text.

--- a/sphinx_js/doclets.py
+++ b/sphinx_js/doclets.py
@@ -167,14 +167,14 @@ def process_see_list(see):
 
 def process_see_item_text(item):
     """Process a single @see tag text value.
-    
+
     Rolls up into a single line text value.
     """
     lines = item.splitlines()
     lines = [line.strip() for line in lines]
     item = ' '.join(lines)
     return item
-    
+
 
 def root_or_fallback(root_for_relative_paths, abs_source_paths):
     """Return the path that relative JS entity paths in the docs are relative to.

--- a/sphinx_js/doclets.py
+++ b/sphinx_js/doclets.py
@@ -158,10 +158,23 @@ def process_see_list(see):
     Translates other values into RST crossreferences.
     """
     for i, item in enumerate(see):
-        if ' ' not in item:
+        if ' ' in item:
+            item = process_see_item_text(item)
+        else:
             item = ':any:`%s`' % item
-            see[i] = item
+        see[i] = item
 
+
+def process_see_item_text(item):
+    """Process a single @see tag text value.
+    
+    Rolls up into a single line text value.
+    """
+    lines = item.splitlines()
+    lines = [line.strip() for line in lines]
+    item = ' '.join(lines)
+    return item
+    
 
 def root_or_fallback(root_for_relative_paths, abs_source_paths):
     """Return the path that relative JS entity paths in the docs are relative to.

--- a/sphinx_js/templates/common.rst
+++ b/sphinx_js/templates/common.rst
@@ -23,8 +23,8 @@
 {% if items -%}
 .. seealso::
 
-   {% for reference in items -%}
-   - :any:`{{ reference }}`
+   {% for item in items -%}
+   - {{ item }}
    {% endfor %}
 {%- endif %}
 {% endmacro %}

--- a/tests/test_build/source/code.js
+++ b/tests/test_build/source/code.js
@@ -202,6 +202,9 @@ class DeprecatedExplanatoryClass {}
  * @see deprecatedFunction
  * @see DeprecatedAttribute
  * @see Freeform text see note.
+ * @see Multiline freeform
+ *     text see
+ *     note.
  */
 function seeFunction() {}
 /**
@@ -209,6 +212,9 @@ function seeFunction() {}
  * @see deprecatedFunction
  * @see DeprecatedAttribute
  * @see Freeform text see note.
+ * @see Multiline freeform
+ *     text see
+ *     note.
  */
 const SeeAttribute = null;
 /**
@@ -216,5 +222,8 @@ const SeeAttribute = null;
  * @see deprecatedFunction
  * @see DeprecatedAttribute
  * @see Freeform text see note.
+ * @see Multiline freeform
+ *     text see
+ *     note.
  */
 class SeeClass {}

--- a/tests/test_build/source/code.js
+++ b/tests/test_build/source/code.js
@@ -201,17 +201,20 @@ class DeprecatedExplanatoryClass {}
  * @see DeprecatedClass
  * @see deprecatedFunction
  * @see DeprecatedAttribute
+ * @see Freeform text see note.
  */
 function seeFunction() {}
 /**
  * @see DeprecatedClass
  * @see deprecatedFunction
  * @see DeprecatedAttribute
+ * @see Freeform text see note.
  */
 const SeeAttribute = null;
 /**
  * @see DeprecatedClass
  * @see deprecatedFunction
  * @see DeprecatedAttribute
+ * @see Freeform text see note.
  */
 class SeeClass {}

--- a/tests/test_build/test_build.py
+++ b/tests/test_build/test_build.py
@@ -125,7 +125,8 @@ class Tests(SphinxBuildTestCase):
             '   See also:\n\n'
             '     * "DeprecatedClass"\n\n'
             '     * "deprecatedFunction"\n\n'
-            '     * "DeprecatedAttribute"\n')
+            '     * "DeprecatedAttribute"\n\n'
+            '     * Freeform text see note.\n')
 
     def test_autoclass(self):
         """Make sure classes show their class comment and constructor
@@ -208,7 +209,8 @@ class Tests(SphinxBuildTestCase):
             '   See also:\n\n'
             '     * "DeprecatedClass"\n\n'
             '     * "deprecatedFunction"\n\n'
-            '     * "DeprecatedAttribute"\n')
+            '     * "DeprecatedAttribute"\n\n'
+            '     * Freeform text see note.\n')
 
     def test_autoattribute(self):
         """Make sure ``autoattribute`` works."""
@@ -243,7 +245,8 @@ class Tests(SphinxBuildTestCase):
             '   See also:\n\n'
             '     * "DeprecatedClass"\n\n'
             '     * "deprecatedFunction"\n\n'
-            '     * "DeprecatedAttribute"\n')
+            '     * "DeprecatedAttribute"\n\n'
+            '     * Freeform text see note.\n')
 
     def test_getter_setter(self):
         """Make sure ES6-style getters and setters can be documented."""

--- a/tests/test_build/test_build.py
+++ b/tests/test_build/test_build.py
@@ -126,7 +126,8 @@ class Tests(SphinxBuildTestCase):
             '     * "DeprecatedClass"\n\n'
             '     * "deprecatedFunction"\n\n'
             '     * "DeprecatedAttribute"\n\n'
-            '     * Freeform text see note.\n')
+            '     * Freeform text see note.\n\n'
+            '     * Multiline freeform text see note.\n')
 
     def test_autoclass(self):
         """Make sure classes show their class comment and constructor
@@ -210,7 +211,8 @@ class Tests(SphinxBuildTestCase):
             '     * "DeprecatedClass"\n\n'
             '     * "deprecatedFunction"\n\n'
             '     * "DeprecatedAttribute"\n\n'
-            '     * Freeform text see note.\n')
+            '     * Freeform text see note.\n\n'
+            '     * Multiline freeform text see note.\n')
 
     def test_autoattribute(self):
         """Make sure ``autoattribute`` works."""
@@ -246,7 +248,8 @@ class Tests(SphinxBuildTestCase):
             '     * "DeprecatedClass"\n\n'
             '     * "deprecatedFunction"\n\n'
             '     * "DeprecatedAttribute"\n\n'
-            '     * Freeform text see note.\n')
+            '     * Freeform text see note.\n\n'
+            '     * Multiline freeform text see note.\n')
 
     def test_getter_setter(self):
         """Make sure ES6-style getters and setters can be documented."""


### PR DESCRIPTION
Proposing support for `@see` tags with freeform text values. Tests are included.

The [JSDoc manual](http://usejsdoc.org/tags-see.html) gives 2 forms of `@see` values: a reference and freeform text. The current logic only supports references. This change adds support for the text form.

```js
/**
 * @see module:frobnicator.Frobnicator#frobnicate
 * @see Linux manpage for foo.
 */
```

The extant support seems to interpret values as references to Sphinx entities rather than JSDoc namepaths. This change keeps that behavior for references.

The new logic interprets the value as text if it contains any space characters. This is a bit of a hack but should work for most cases. If JSDoc namepath support is ever added, it could be changed to attempt namepath resolution and failover to text for consistency with JSDoc behavior.

Prepares for supporting Markdown in `@see` text values.