### PR TITLE
Failing test case showing messed up order of constructor

### DIFF
--- a/tests/test_build_ts/source/class.ts
+++ b/tests/test_build_ts/source/class.ts
@@ -1,0 +1,20 @@
+/**
+ * A definition of a class
+ */
+class ClassDefinition {
+    /**
+     * ClassDefinition constructor
+     * @param simple A parameter with a simple type
+     */
+    constructor(simple: number) {
+
+    }
+
+    /**
+     * This is a method without return type
+     * @param simple A parameter with a simple type
+     */
+    method1(simple: number) : void {
+
+    }
+}

--- a/tests/test_build_ts/source/docs/conf.py
+++ b/tests/test_build_ts/source/docs/conf.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+extensions = [
+    'sphinx_js'
+]
+
+# Minimal stuff needed for Sphinx to work:
+source_suffix = '.rst'
+master_doc = 'index'
+author = u'Erik Rose'
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+jsdoc_config_path = '../tsconfig.json'
+js_language = 'typescript'

--- a/tests/test_build_ts/source/docs/index.rst
+++ b/tests/test_build_ts/source/docs/index.rst
@@ -1,0 +1,2 @@
+.. js:autoclass:: ClassDefinition
+   :members:

--- a/tests/test_build_ts/source/tsconfig.json
+++ b/tests/test_build_ts/source/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "compilerOptions": {
+      "target": "es6",
+      "module": "commonjs",
+      "moduleResolution": "node"
+    }
+  }

--- a/tests/test_build_ts/test_build.py
+++ b/tests/test_build_ts/test_build.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from nose.tools import assert_true
+
+from tests.testing import SphinxBuildTestCase
+
+
+class Tests(SphinxBuildTestCase):
+    """Tests which require our one big Sphinx tree to be built
+    (typescript version)
+    """
+
+    def test_autoclass_constructor(self):
+        """Make sure class constructor comes before methods."""
+        contents = self._file_contents('index')
+        pos_method = contents.index("ClassDefinition.method1")
+        pos_cstrct = contents.index("ClassDefinition.new ClassDefinition")
+        assert_true(pos_method > pos_cstrct, "Constructor appears after method in " + contents)


### PR DESCRIPTION
Output of this test

```
======================================================================
FAIL: test_autoclass_constructor (test_build.Tests)
Make sure constructor comes before methods.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/paulgrau/projects/opensource/sphinx-js/tests/test_build_ts/test_build.py", line 17, in test_autoclass_constructor
    assert_true(pos_method > pos_cstrct, "Constructor appears after method in " + contents)
AssertionError: Constructor appears after method in class ClassDefinition()

   A definition of a class

   ClassDefinition.method1(simple)

      This is a method without return type

      Arguments:
         * **simple** (*number*) -- A parameter with a simple type

   ClassDefinition.new ClassDefinition(simple)

      ClassDefinition constructor

      Arguments:
         * **simple** (*number*) -- A parameter with a simple type

      Returns:
         **class.ClassDefinition** --


----------------------------------------------------------------------
```


Expected build output (correct order):

```
class ClassDefinition()

   A definition of a class

   ClassDefinition.new ClassDefinition(simple)

      ClassDefinition constructor

      Arguments:
         * **simple** (*number*) -- A parameter with a simple type

      Returns:
         **class.ClassDefinition** --

   ClassDefinition.method1(simple)

      This is a method without return type

      Arguments:
         * **simple** (*number*) -- A parameter with a simple type
```

but the `ClassDefinition.new ClassDefinition(simple)` is a bit ugly, too. Not sure what the best way would be.