### PR TITLE
Fix typedoc parsing code broken since typedoc@0.14.0. Fixes #90

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
   - "3.6"
 install:
   - npm install jsdoc@3.5.5
-  - npm install typedoc@0.11.1
+  - npm install typedoc@0.14.1
   - pip install tox-travis
 script:
   - PATH=$TRAVIS_BUILD_DIR/node_modules/.bin:$PATH tox

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -288,9 +288,9 @@ class TypeDoc(object):
         elif kindString == 'Accessor':
             doclet = self.simple_doclet('member', node)
             if node.get('getSignature'):
-                type = self.make_type(node['getSignature']['type'])
+                type = self.make_type(node['getSignature'][0]['type'])
             else:
-                type_name = node['setSignature']['parameters'][0]['type']
+                type_name = node['setSignature'][0]['parameters'][0]['type']
                 type = self.make_type(type_name)
             self.extend_doclet(doclet, type=type)
 


### PR DESCRIPTION
Without this change and typedoc@0.14.0, the tests of sphinx-js actually fail (same error as reported in #90). This change makes tests pass again. 

I *think* there will always be only one signature per accessor? But not 100% sure about that.

## Steps to reproduce

    npm install -g typedoc@0.14.0
    python setup.py test

Fails on current master, passes with this change.
