### PR TITLE
Change url in setup.py from a fork to the main repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,3 @@ sphinx_js.egg-info/
 */__pycache__/*
 # Python 2.7
 *.pyc
-# Pycharm config
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ sphinx_js.egg-info/
 */__pycache__/*
 # Python 2.7
 *.pyc
+# Pycharm config
+.idea

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
                    # time to time:
                    'Sphinx==1.7.2'],
     test_suite='nose.collector',
-    url='https://github.com/erikrose/sphinx-js',
+    url='https://github.com/mozilla/sphinx-js',
     include_package_data=True,
     install_requires=['docutils', 'Jinja2>2.0,<3.0', 'parsimonious>=0.7.0,<0.8.0', 'six>=1.9.0,<2.0', 'Sphinx<2.0'],
     classifiers=[


### PR DESCRIPTION
When I initially found this project on PyPi I followed the link to the homepage and got to the fork of @erikrose and had to click again to get here. Even so this isn't a big issue, it is always nice to save a click here and there 😄 