### PR TITLE
Solves error for tuples without elements key

### DIFF
--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -133,7 +133,7 @@ class TypeDoc(object):
             names = ['"' + type.get('value') + '"']
         elif type.get('type') == 'array':
             names = [self.make_type_name(type.get('elementType')) + '[]']
-        elif type.get('type') == 'tuple':
+        elif type.get('type') == 'tuple' and type.get('elements'):
             types = [self.make_type_name(t) for t in type.get('elements')]
             names = ['[' + ','.join(types) + ']']
         elif type.get('type') == 'union':


### PR DESCRIPTION
This solves the problem where some tuple types didn't actually have any "elements" prop on the json from typedoc

JSON data example:

	{
		"id": 11668,
		"name": "Props",
		"kind": 256,
		"kindString": "Interface",
		"flags": {},
		"children": [
			{
				"id": 11669,
				"name": "options",
				"kind": 1024,
				"kindString": "Property",
				"flags": {},
				"comment": {
					"shortText": "Array with different form options from package"
				},
				"sources": [
					{
						"fileName": "App/Components/TcombDatePicker/TcombDatePicker.tsx",
						"line": 18,
						"character": 9
					}
				],
				"type": {
					"type": "tuple"
				}
			}
		],
		"groups": [
			{
				"title": "Properties",
				"kind": 1024,
				"children": [
					11669
				]
			}
		],
		"sources": [
			{
				"fileName": "App/Components/TcombDatePicker/TcombDatePicker.tsx",
				"line": 14,
				"character": 15
			}
		]
	}