### PR TITLE
Typescript doclet order and generic types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ sphinx_js.egg-info/
 .idea
 # VsCode config
 .vscode
+.DS_Store

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -291,7 +291,7 @@ class AutoClassRenderer(JsRenderer):
             if '*' in included_set:
                 star_index = include.index('*')
                 sorted_not_included_doclets = sorted(
-                    [d for d in doclets if d['name'] not in included_set],
+                    (d for d in doclets if d['name'] not in included_set),
                     key=lambda d: d.get('longname', d['name'])
                 )
                 not_included = [d['name'] for d in sorted_not_included_doclets]

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -283,14 +283,18 @@ class AutoClassRenderer(JsRenderer):
             doclets = self._app._sphinxjs_doclets_by_class[tuple(full_path)]
             if not include:
                 # Specifying none means listing all.
-                return sorted(doclets, key=lambda d: d['name'])
+                return sorted(doclets, key=lambda d: d.get('longname', d['name']))
             included_set = set(include)
 
             # If the special name * is included in the list, include
             # all other doclets, in sorted order.
             if '*' in included_set:
                 star_index = include.index('*')
-                not_included = sorted(d['name'] for d in doclets if d['name'] not in included_set)
+                sorted_not_included_doclets = sorted(
+                    [d for d in doclets if d['name'] not in included_set],
+                    key=lambda d: d.get('longname', d['name'])
+                )
+                not_included = [d['name'] for d in sorted_not_included_doclets]
                 include = include[:star_index] + not_included + include[star_index + 1:]
                 included_set.update(not_included)
 

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -149,8 +149,9 @@ class TypeDoc(object):
         elif type.get('type') == 'reflection':
             names = ['<TODO>']
         if type.get('typeArguments'):
-            argNames = ', '.join([self.make_type_name(arg) for arg in type.get('typeArguments')])
-            names = [names[0] + "<" + argNames + ">"]
+            # TODO: doesnt work with union 
+            argNames = [', '.join(self.make_type_name(arg)) for arg in type.get('typeArguments')]
+            names = [names[0] + '<' + ', '.join(argNames) + '>']
         return names
 
     def make_type(self, type):

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -148,6 +148,9 @@ class TypeDoc(object):
                 names.extend(['extends', self.make_type_name(constraint)])
         elif type.get('type') == 'reflection':
             names = ['<TODO>']
+        if type.get('typeArguments'):
+            argNames = ', '.join([self.make_type_name(arg) for arg in type.get('typeArguments')])
+            names = [names[0] + "<" + argNames + ">"]
         return names
 
     def make_type(self, type):

--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -134,7 +134,7 @@ class TypeDoc(object):
         elif type.get('type') == 'array':
             names = [self.make_type_name(type.get('elementType'))[0] + '[]']
         elif type.get('type') == 'tuple' and type.get('elements'):
-            types = [self.make_type_name(t) for t in type.get('elements')]
+            types = ['|'.join(self.make_type_name(t)) for t in type.get('elements')]
             names = ['[' + ','.join(types) + ']']
         elif type.get('type') == 'union':
             names = [self.make_type_name(t)[0] for t in type.get('types') if self.make_type_name(t)]
@@ -149,9 +149,8 @@ class TypeDoc(object):
         elif type.get('type') == 'reflection':
             names = ['<TODO>']
         if type.get('typeArguments'):
-            # TODO: doesnt work with union 
-            argNames = [', '.join(self.make_type_name(arg)) for arg in type.get('typeArguments')]
-            names = [names[0] + '<' + ', '.join(argNames) + '>']
+            argNames = ['|'.join(self.make_type_name(arg)) for arg in type.get('typeArguments')]
+            names = [names[0] + '<' + ','.join(argNames) + '>']
         return names
 
     def make_type(self, type):

--- a/tests/test_build_ts/source/class.ts
+++ b/tests/test_build_ts/source/class.ts
@@ -2,6 +2,8 @@
  * A definition of a class
  */
 class ClassDefinition {
+    field: string;
+
     /**
      * ClassDefinition constructor
      * @param simple A parameter with a simple type
@@ -15,6 +17,13 @@ class ClassDefinition {
      * @param simple A parameter with a simple type
      */
     method1(simple: number) : void {
+
+    }
+
+    /**
+     * This is a method (should be before method 'method1', but after fields)
+     */
+    anotherMethod() {
 
     }
 }

--- a/tests/test_build_ts/source/class.ts
+++ b/tests/test_build_ts/source/class.ts
@@ -1,0 +1,20 @@
+/**
+ * A definition of a class
+ */
+class ClassDefinition {
+    /**
+     * ClassDefinition constructor
+     * @param simple A parameter with a simple type
+     */
+    constructor(simple: number) {
+
+    }
+
+    /**
+     * This is a method without return type
+     * @param simple A parameter with a simple type
+     */
+    method1(simple: number) : void {
+
+    }
+}

--- a/tests/test_build_ts/source/docs/autoclass_star.rst
+++ b/tests/test_build_ts/source/docs/autoclass_star.rst
@@ -1,0 +1,2 @@
+.. js:autoclass:: ClassDefinition
+   :members: method1, *

--- a/tests/test_build_ts/source/docs/conf.py
+++ b/tests/test_build_ts/source/docs/conf.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+extensions = [
+    'sphinx_js'
+]
+
+# Minimal stuff needed for Sphinx to work:
+source_suffix = '.rst'
+master_doc = 'index'
+author = u'Erik Rose'
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+jsdoc_config_path = '../tsconfig.json'
+js_language = 'typescript'

--- a/tests/test_build_ts/source/docs/index.rst
+++ b/tests/test_build_ts/source/docs/index.rst
@@ -1,0 +1,2 @@
+.. js:autoclass:: ClassDefinition
+   :members:

--- a/tests/test_build_ts/source/tsconfig.json
+++ b/tests/test_build_ts/source/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "compilerOptions": {
+      "target": "es6",
+      "module": "commonjs",
+      "moduleResolution": "node"
+    }
+  }

--- a/tests/test_build_ts/test_build.py
+++ b/tests/test_build_ts/test_build.py
@@ -5,13 +5,35 @@ from tests.testing import SphinxBuildTestCase
 
 
 class Tests(SphinxBuildTestCase):
-    """Tests which require our one big Sphinx tree to be built
-    (typescript version)
-    """
+    """Tests which require our one big Sphinx tree to be built (typescript version)"""
 
     def test_autoclass_constructor(self):
         """Make sure class constructor comes before methods."""
         contents = self._file_contents('index')
-        pos_method = contents.index("ClassDefinition.method1")
-        pos_cstrct = contents.index("ClassDefinition.new ClassDefinition")
-        assert_true(pos_method > pos_cstrct, "Constructor appears after method in " + contents)
+        pos_cstrct = contents.index('ClassDefinition constructor')
+        pos_method = contents.index('ClassDefinition.method1')
+        assert_true(pos_method > pos_cstrct, 'Constructor appears after method in ' + contents)
+
+    def test_autoclass_order(self):
+        """Make sure fields come before methods."""
+        contents = self._file_contents('index')
+        pos_field = contents.index('ClassDefinition.field')
+        pos_method2 = contents.index('ClassDefinition.anotherMethod')
+        pos_method = contents.index('ClassDefinition.method1')
+        assert_true(pos_field < pos_method2 < pos_method, 'Methods and fields are not in right order in ' + contents)
+
+    def test_autoclass_star_order(self):
+        """Make sure fields come before methods even when using ``*``."""
+        contents = self._file_contents('autoclass_star')
+        pos_method = contents.index('ClassDefinition.method1')
+        pos_field = contents.index('ClassDefinition.field')
+        pos_method2 = contents.index('ClassDefinition.anotherMethod')
+        assert_true(pos_method < pos_field < pos_method2, 'Methods and fields are not in right order in ' + contents)
+
+    def test_generic_type(self):
+        """Make sure all information about generic type is rendered"""
+        contents = self._file_contents('index')
+        assert_true(
+            '**generic** (*Promise<Partial<class.ClassDefinition>>*)' in contents,
+            'Generic type is rendered incompletely in ' + contents
+        )

--- a/tests/test_build_ts/test_build.py
+++ b/tests/test_build_ts/test_build.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from nose.tools import assert_true
+
+from tests.testing import SphinxBuildTestCase
+
+
+class Tests(SphinxBuildTestCase):
+    """Tests which require our one big Sphinx tree to be built
+    (typescript version)
+    """
+
+    def test_autoclass_constructor(self):
+        """Make sure class constructor comes before methods."""
+        contents = self._file_contents('index')
+        pos_method = contents.index("ClassDefinition.method1")
+        pos_cstrct = contents.index("ClassDefinition.new ClassDefinition")
+        assert_true(pos_method > pos_cstrct, "Constructor appears after method in " + contents)

--- a/tests/test_build_ts/test_build.py
+++ b/tests/test_build_ts/test_build.py
@@ -29,11 +29,3 @@ class Tests(SphinxBuildTestCase):
         pos_field = contents.index('ClassDefinition.field')
         pos_method2 = contents.index('ClassDefinition.anotherMethod')
         assert_true(pos_method < pos_field < pos_method2, 'Methods and fields are not in right order in ' + contents)
-
-    def test_generic_type(self):
-        """Make sure all information about generic type is rendered"""
-        contents = self._file_contents('index')
-        assert_true(
-            '**generic** (*Promise<Partial<class.ClassDefinition>>*)' in contents,
-            'Generic type is rendered incompletely in ' + contents
-        )

--- a/tests/test_typedoc.py
+++ b/tests/test_typedoc.py
@@ -31,6 +31,7 @@ class Tests(TestCase):
             typedoc_command_name,
             '--out', self.tmpdir,
             '--ignoreCompilerErrors',
+            '--target', 'ES6',
             '--json', outfile,
             os.path.join(self.source_dir, source)
         ])

--- a/tests/typescript/generic-class.ts
+++ b/tests/typescript/generic-class.ts
@@ -2,16 +2,16 @@
  * A definition of a generic class
  */
 class GenericClass<T> {
-
     /**
      * Generic member type
      */
     member:T
+
     /**
      * GenericClass constructor
      * @param arg Generic as argument
      */
-    constructor(arg:T) {
+    constructor(arg: T) {
     	this.member = arg
     }
 
@@ -19,7 +19,7 @@ class GenericClass<T> {
      * This is a method with a generic return type
      * @returns 42
      */
-    method2() : T {
+    method2(): T {
         return this.member
     }
 }

--- a/tests/typescript/generic-class.ts.jsdoc
+++ b/tests/typescript/generic-class.ts.jsdoc
@@ -53,7 +53,7 @@
         "meta": {
             "code": {},
             "filename": "generic-class.ts",
-            "lineno": 9,
+            "lineno": 8,
             "path": "./"
         },
         "name": "member",

--- a/tests/typescript/generic-complex.ts
+++ b/tests/typescript/generic-complex.ts
@@ -1,0 +1,13 @@
+/**
+ * A definition of a class, using generic types containing unions and lists
+ */
+class ClassWithComplexGenericMethodArgs {
+    /**
+     * A generic method
+     * @param arg a generic argument
+     * @returns a value of the generic type
+     */
+    async method<T>(arg: Partial<T|number>): Promise<[Partial<T|number>, number]> {
+        return [arg, 1];
+    }
+}

--- a/tests/typescript/generic-complex.ts.jsdoc
+++ b/tests/typescript/generic-complex.ts.jsdoc
@@ -1,0 +1,72 @@
+[
+    {
+        "comment": "<empty>",
+        "description": "",
+        "kind": "external",
+        "longname": "external:generic-complex",
+        "meta": {
+            "code": {},
+            "filename": "generic-complex.ts",
+            "lineno": 1,
+            "path": "./"
+        },
+        "name": "\"generic-complex\""
+    },
+    {
+        "classdesc": "",
+        "comment": "<empty>",
+        "description": "A definition of a class, using generic types containing unions and lists\n\n",
+        "extends": [],
+        "kind": "class",
+        "longname": "external:generic-complex~ClassWithComplexGenericMethodArgs",
+        "memberof": "external:generic-complex",
+        "meta": {
+            "code": {},
+            "filename": "generic-complex.ts",
+            "lineno": 4,
+            "path": "./"
+        },
+        "name": "ClassWithComplexGenericMethodArgs",
+        "params": []
+    },
+    {
+        "comment": "<empty>",
+        "description": "A generic method\n\n",
+        "kind": "function",
+        "longname": "external:generic-complex~ClassWithComplexGenericMethodArgs.method",
+        "memberof": "external:generic-complex~ClassWithComplexGenericMethodArgs",
+        "meta": {
+            "code": {
+                "paramnames": [
+                    "arg"
+                ]
+            },
+            "filename": "generic-complex.ts",
+            "lineno": 10,
+            "path": "./"
+        },
+        "name": "method",
+        "params": [
+            {
+                "description": "\n\na generic argument",
+                "name": "arg",
+                "type": {
+                    "names": [
+                        "Partial<T|number>"
+                    ]
+                }
+            }
+        ],
+        "returns": [
+            {
+                "description": "a value of the generic type\n",
+                "name": "method",
+                "type": {
+                    "names": [
+                        "Promise<[Partial<T|number>,number]>"
+                    ]
+                }
+            }
+        ]
+    }
+]

--- a/tests/typescript/generic-interface.ts
+++ b/tests/typescript/generic-interface.ts
@@ -5,11 +5,11 @@ interface GenericInterface<T> {
     /**
      * Generic member type
      */
-    member:T
+    member: T
 
     /**
      * This is a method with a generic return type
      * @returns 42
      */
-    method2() : T
+    method2(): T
 }


### PR DESCRIPTION
This is a fix for #98. It builds on top of #92 (should be merged first). This works by recursively calling `make_type_name` when we have `typeArguments`.

This PR additionally changes the order of fields (they should come before methods) by using the `longname` for sorting instead of just the name.

I also added a build test for typescript.

Let's merge #92 first and then review this PR separately.