### PR TITLE
Use pytest

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+end_of_line = lf
+
+[*.bat]
+indent_style = tab
+end_of_line = crlf
+
+[*.csv]
+indent_style = tab
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[LICENSE]
+insert_final_newline = false
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.eggs
 /.tox
+/.pytest_cache
 /build
 /dist
 /tests/source/docs/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   fast_finish: true
   include:
     - python: 3.6
-      env: TOXENV=py36-flake
+      env: TOXENV=flake8
       install: pip install tox
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,14 @@ addons:
 python:
   - "2.7"
   - "3.6"
+
+matrix:
+  fast_finish: true
+  include:
+    - python: 3.6
+      env: TOXENV=py36-flake
+      install: pip install tox
+
 install:
   - npm install jsdoc@3.5.5
   - npm install typedoc@0.14.1

--- a/README.rst
+++ b/README.rst
@@ -330,7 +330,10 @@ Caveats
 Tests
 =====
 
-Run ``python setup.py test``. Run ``tox`` to test across Python versions.
+To test modified code you will need to have all dependencies installed ``npm i -g jsdoc typedoc``,
+``pip install -r requirements_dev.txt`` and ``pip install -e .``.
+The tests can than simply be run by run ``pytest`` in the root folder of the project.
+To test across different Python versions, run ``tox``.
 
 Version History
 ===============

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
-
-  pytest
-  recommonmark==0.4.0
+tox
+pytest
+recommonmark==0.4.0
 # Sphinx's plain-text renderer changes behavior slightly
 # with regard to how it emits class names and em dashes from
 # time to time:
-  Sphinx==1.7.2
+Sphinx==1.7.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,7 @@
+
+  pytest
+  recommonmark==0.4.0
+# Sphinx's plain-text renderer changes behavior slightly
+# with regard to how it emits class names and em dashes from
+# time to time:
+  Sphinx==1.7.2

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,4 @@
-# Prevent spurious errors during `python setup.py test` in 2.6, a la
-# http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html:
-try:
-    import multiprocessing
-except ImportError:
-    pass
-
+# -*- coding: utf-8 -*-
 from io import open
 from setuptools import setup, find_packages
 
@@ -14,17 +8,11 @@ setup(
     version='2.7.1',
     description='Support for using Sphinx on JSDoc-documented JS code',
     long_description=open('README.rst', 'r', encoding='utf8').read(),
+    long_description_content_type="text/x-rst",
     author='Erik Rose',
     author_email='erikrose@grinchcentral.com',
     license='MIT',
     packages=find_packages(exclude=['ez_setup']),
-    tests_require=['nose',
-                   'recommonmark==0.4.0',
-                   # Sphinx's plain-text renderer changes behavior slightly
-                   # with regard to how it emits class names and em dashes from
-                   # time to time:
-                   'Sphinx==1.7.2'],
-    test_suite='nose.collector',
     url='https://github.com/mozilla/sphinx-js',
     include_package_data=True,
     install_requires=['docutils', 'Jinja2>2.0,<3.0', 'parsimonious>=0.7.0,<0.8.0', 'six>=1.9.0,<2.0', 'Sphinx<2.0'],
@@ -39,5 +27,5 @@ setup(
         'Topic :: Documentation :: Sphinx',
         'Topic :: Software Development :: Documentation'
         ],
-    keywords=['sphinx', 'documentation', 'docs', 'javascript', 'js', 'jsdoc', 'restructured'],
+    keywords=['sphinx', 'documentation', 'docs', 'javascript', 'js', 'jsdoc', 'restructured', 'typescript', 'typedoc'],
 )

--- a/tests/test_build/test_build.py
+++ b/tests/test_build/test_build.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from nose.tools import assert_in, assert_not_in
-
 from tests.testing import SphinxBuildTestCase
 
 
@@ -131,8 +129,8 @@ class Tests(SphinxBuildTestCase):
         """Make sure classes show their class comment and constructor
         comment."""
         contents = self._file_contents('autoclass')
-        assert_in('Class doc.', contents)
-        assert_in('Constructor doc.', contents)
+        assert 'Class doc.' in contents
+        assert 'Constructor doc.' in contents
 
     def test_autoclass_members(self):
         """Make sure classes list their members if ``:members:`` is specified.
@@ -171,15 +169,15 @@ class Tests(SphinxBuildTestCase):
         """Make sure classes list their private members if
         ``:private-members:`` is specified."""
         contents = self._file_contents('autoclass_private_members')
-        assert_in('secret()', contents)
+        assert 'secret()' in contents
 
     def test_autoclass_exclude_members(self):
         """Make sure ``exclude-members`` option actually excludes listed
         members."""
         contents = self._file_contents('autoclass_exclude_members')
-        assert_in('publical()', contents)
-        assert_not_in('publical2', contents)
-        assert_not_in('publical3', contents)
+        assert 'publical()' in contents
+        assert 'publical2' not in contents
+        assert 'publical3' not in contents
 
     def test_autoclass_example(self):
         """Make sure @example tags can be documented with autoclass."""

--- a/tests/test_doclets.py
+++ b/tests/test_doclets.py
@@ -1,6 +1,7 @@
+# -*- coding: utf-8 -*-
 from os.path import abspath
 
-from nose.tools import assert_raises, eq_
+import pytest
 from sphinx.errors import SphinxError
 
 from sphinx_js.doclets import doclet_full_path, root_or_fallback
@@ -15,14 +16,21 @@ def test_doclet_full_path():
         },
         'longname': 'best#thing~yeah'
     }
-    eq_(doclet_full_path(doclet, '/boogie/smoo/Checkouts'),
-        ['./', 'fathom/', 'utils.', 'best#', 'thing~', 'yeah'])
+    assert doclet_full_path(doclet, '/boogie/smoo/Checkouts') == [
+        './',
+        'fathom/',
+        'utils.',
+        'best#',
+        'thing~',
+        'yeah',
+    ]
 
 
 def test_relative_path_root():
     """Make sure the computation of the root path for relative JS entity
     pathnames is right."""
     # Fall back to the only source path if not specified.
-    eq_(root_or_fallback(None, ['a']), 'a')
-    assert_raises(SphinxError, root_or_fallback, None, ['a', 'b'])
-    eq_(root_or_fallback('smoo', ['a']), abspath('smoo'))
+    assert root_or_fallback(None, ['a']) == 'a'
+    with pytest.raises(SphinxError):
+        root_or_fallback(None, ['a', 'b'])
+    assert root_or_fallback('smoo', ['a']) == abspath('smoo')

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,9 +1,10 @@
-from nose.tools import eq_
-
+# -*- coding: utf-8 -*-
 from sphinx_js.parsers import PathVisitor
 
 
 def test_escapes():
     r"""Make sure escapes work right and Python escapes like \n don't work."""
-    eq_(PathVisitor().parse(r'd\.i:\nr/ut\\ils.max(whatever)'),
-        [[r'd.i:nr/', 'ut\ils.', 'max'], '(whatever)'])
+    assert PathVisitor().parse(r'd\.i:\nr/ut\\ils.max(whatever)') == [
+        [r'd.i:nr/', 'ut\ils.', 'max'],
+        '(whatever)',
+    ]

--- a/tests/test_suffix_tree.py
+++ b/tests/test_suffix_tree.py
@@ -1,4 +1,5 @@
-from nose.tools import assert_raises, eq_
+# -*- coding: utf-8 -*-
+import pytest
 
 from sphinx_js.suffix_tree import SuffixAmbiguous, SuffixNotFound, SuffixTree
 
@@ -9,7 +10,9 @@ def test_things():
     s.add(['./', 'dir/', 'footils.', 'max'], 2)
     s.add(['./', 'dir/', 'footils.', 'hacks'], 3)
 
-    eq_(s.get(['hacks']), 3)
-    eq_(s.get(['footils.', 'max']), 2)
-    assert_raises(SuffixNotFound, s.get, ['quacks.', 'max'])
-    assert_raises(SuffixAmbiguous, s.get, ['max'])
+    assert s.get(['hacks']) == 3
+    assert s.get(['footils.', 'max']) == 2
+    with pytest.raises(SuffixNotFound):
+        s.get(['quacks.', 'max'])
+    with pytest.raises(SuffixAmbiguous):
+        s.get(['max'])

--- a/tests/test_typedoc.py
+++ b/tests/test_typedoc.py
@@ -1,11 +1,10 @@
+# -*- coding: utf-8 -*-
 import os
 import subprocess
 import shutil
 import json
 from unittest import TestCase
 from tempfile import mkdtemp
-
-from nose.tools import eq_
 
 from sphinx_js.doclets import program_name_on_this_platform
 from sphinx_js.typedoc import TypeDoc, parse_typedoc
@@ -39,7 +38,7 @@ class Tests(TestCase):
     def test_empty(self):
         json = {}
         jsdoc = TypeDoc(json).jsdoc
-        eq_(jsdoc, [])
+        assert jsdoc == []
 
     def test_references(self):
         for source in os.listdir(self.source_dir):
@@ -62,4 +61,4 @@ class Tests(TestCase):
                 else:
                     with open(jsdoc_ref_file, 'r') as jsdocfile:
                         jsdoc_ref = json.load(jsdocfile)
-                    eq_(jsdoc, jsdoc_ref)
+                    assert jsdoc == jsdoc_ref

--- a/tests/test_typedoc.py
+++ b/tests/test_typedoc.py
@@ -3,62 +3,66 @@ import os
 import subprocess
 import shutil
 import json
-from unittest import TestCase
 from tempfile import mkdtemp
+
+import pytest
 
 from sphinx_js.doclets import program_name_on_this_platform
 from sphinx_js.typedoc import TypeDoc, parse_typedoc
 
+TS_SOURCE_DIR = os.path.join(os.path.dirname(__file__), 'typescript')
+TS_FILE_LIST = list(filter(lambda x: x.endswith('.ts'), os.listdir(TS_SOURCE_DIR)))
 
-class Tests(TestCase):
-    """Test typedoc to jsdoc conversion on typescript/*.ts
-    """
-    @classmethod
-    def setup_class(cls):
-        cls.source_dir = os.path.join(os.path.dirname(__file__), 'typescript')
-        cls.tmpdir = mkdtemp()
 
-    @classmethod
-    def teardown_class(cls):
-        shutil.rmtree(cls.tmpdir)
+@pytest.fixture(scope='module')
+def typedoc():
+    tmpdir = mkdtemp()
 
-    def typedoc(self, source):
-        outfile = os.path.join(self.tmpdir, source + '.json')
+    def inner_func(source):
+        outfile = os.path.join(tmpdir, source + '.json')
         typedoc_command_name = program_name_on_this_platform('typedoc')
 
         subprocess.call([
             typedoc_command_name,
-            '--out', self.tmpdir,
+            '--out', tmpdir,
             '--ignoreCompilerErrors',
             '--json', outfile,
-            os.path.join(self.source_dir, source)
+            os.path.join(TS_SOURCE_DIR, source)
         ])
         return outfile
+    yield inner_func
+    shutil.rmtree(tmpdir)
 
-    def test_empty(self):
-        json = {}
-        jsdoc = TypeDoc(json).jsdoc
-        assert jsdoc == []
 
-    def test_references(self):
-        for source in os.listdir(self.source_dir):
-            if source.endswith('.ts'):
-                with open(self.typedoc(source), 'r') as typedocfile:
-                    jsdoc = parse_typedoc(typedocfile)
-                jsdoc_ref_file = os.path.join(self.source_dir, source + '.jsdoc')
-                if not os.path.exists(jsdoc_ref_file):
-                    # When a reference file is missing, this is probably a new test.
-                    # Generate a reference file for the developer to review.  If the
-                    # generated reference is good, just remove the '.ref' extension.
-                    with open(jsdoc_ref_file + '.ref', 'w') as jsdocfile:
-                        json.dump(
-                            jsdoc,
-                            jsdocfile,
-                            sort_keys=True,
-                            indent=4,
-                            separators=(',', ': '))
-                    print('wrote %s' % jsdoc_ref_file)
-                else:
-                    with open(jsdoc_ref_file, 'r') as jsdocfile:
-                        jsdoc_ref = json.load(jsdocfile)
-                    assert jsdoc == jsdoc_ref
+@pytest.fixture(params=TS_FILE_LIST)
+def references(request, typedoc):
+    source = request.param
+    with open(typedoc(source), 'r') as typedocfile:
+        jsdoc = parse_typedoc(typedocfile)
+    jsdoc_ref_file = os.path.join(TS_SOURCE_DIR, source + '.jsdoc')
+    if not os.path.exists(jsdoc_ref_file):
+        # When a reference file is missing, this is probably a new test.
+        # Generate a reference file for the developer to review.  If the
+        # generated reference is good, just remove the '.ref' extension.
+        with open(jsdoc_ref_file + '.ref', 'w') as jsdocfile:
+            json.dump(
+                jsdoc,
+                jsdocfile,
+                sort_keys=True,
+                indent=4,
+                separators=(',', ': '))
+        print('wrote %s' % jsdoc_ref_file)
+    else:
+        with open(jsdoc_ref_file, 'r') as jsdocfile:
+            jsdoc_ref = json.load(jsdocfile)
+        return {'jsdoc': jsdoc, 'jsdoc_ref': jsdoc_ref}
+
+
+def test_empty():
+    json = {}
+    jsdoc = TypeDoc(json).jsdoc
+    assert jsdoc == []
+
+
+def test_references(references):
+    assert references['jsdoc'] == references['jsdoc_ref']

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -1,10 +1,10 @@
+# -*- coding: utf-8 -*-
 from io import open
 from os.path import dirname, join
 from shutil import rmtree
 from unittest import TestCase
 import sys
 
-from nose.tools import eq_
 from sphinx.cmdline import main as sphinx_main
 from sphinx.util.osutil import cd
 
@@ -39,4 +39,4 @@ class SphinxBuildTestCase(TestCase):
             return file.read()
 
     def _file_contents_eq(self, filename, contents):
-        eq_(self._file_contents(filename), contents)
+        assert self._file_contents(filename) == contents

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist = py27, py36, py36-flake
 
 [testenv]
-commands = python setup.py test
+deps=-r{toxinidir}/requirements_dev.txt
+commands = pytest
 
 [testenv:py36-flake]
 # Pinned so new checks aren't added by surprise:

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py27, py36, py36-flake
+envlist = py27, py36, flake8
 
 [testenv]
 deps=-r{toxinidir}/requirements_dev.txt
 commands = pytest -vv
 
-[testenv:py36-flake]
+[testenv:flake8]
 # Pinned so new checks aren't added by surprise:
 deps =
     flake8>=3.5,<3.6

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27, py36, py36-flake
 
 [testenv]
 deps=-r{toxinidir}/requirements_dev.txt
-commands = pytest
+commands = pytest -vv
 
 [testenv:py36-flake]
 # Pinned so new checks aren't added by surprise:


### PR DESCRIPTION
This PR changed the used testing framework from `nosetest` to `pytest` due to it's more pythonic syntax and clearer output (see #104 ). The increased number of tests is due to, splitting of reference tests in `test_typedoc.py` to per source file tests, instead of one bit test with a loop.


**closes**
#104 