### PR TITLE
Make tox the unified entrypoint for tests, both local and on CI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.pytest_cache
 /build
 /dist
+/node_modules
 /tests/source/docs/_build
 sphinx_js.egg-info/
 # Python 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
       - npm
 python:
   - "2.7"
-  - "3.6"
+  - "3.7"
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ matrix:
       install: pip install tox
 
 install:
-  - npm install jsdoc@3.5.5
-  - npm install typedoc@0.14.1
   - pip install tox-travis
 script:
-  - PATH=$TRAVIS_BUILD_DIR/node_modules/.bin:$PATH tox
+  - tox

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Setup
 
         npm install -g jsdoc
 
-   We work with jsdoc 3.4.3, 3.5.4, and quite possibly other versions.
+   We work with jsdoc 3.6.3 and quite possibly other versions.
 
 2. Install sphinx-js, which will pull in Sphinx itself as a dependency::
 

--- a/README.rst
+++ b/README.rst
@@ -333,19 +333,10 @@ Caveats
 Tests
 =====
 
-First, install dependencies::
+Run the tests using tox, which will also install jsdoc and typedoc at pinned versions::
 
-    npm i -g jsdoc typedoc
-    pip install -r requirements_dev.txt
-    pip install -e .
-
-Then, run the tests::
-
-    pytest
-
-To test across different Python versions... ::
-
-    tox
+    pip install tox
+    tox -e py37
 
 Version History
 ===============

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,4 @@
-tox
-pytest
+pytest==5.1.2
 recommonmark==0.4.0
 # Sphinx's plain-text renderer changes behavior slightly
 # with regard to how it emits class names and em dashes from

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(exclude=['ez_setup']),
     url='https://github.com/mozilla/sphinx-js',
     include_package_data=True,
-    install_requires=['docutils', 'Jinja2>2.0,<3.0', 'parsimonious>=0.7.0,<0.8.0', 'six>=1.9.0,<2.0', 'Sphinx<3.0'],
+    install_requires=['docutils', 'Jinja2>2.0,<3.0', 'parsimonious>=0.7.0,<0.8.0', 'six>=1.9.0,<2.0', 'Sphinx>=1.6,<3.0'],
     classifiers=[
         'Intended Audience :: Developers',
         'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,10 @@
 envlist = py27, py36, flake8
 
 [testenv]
+setenv = PATH = {toxinidir}/node_modules/.bin:$PATH
 deps = -rrequirements_dev.txt
+whitelist_externals = npm
+commands_pre = npm install --no-save jsdoc@3.6.3 typedoc@0.15.0
 commands = pytest -vv
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,16 @@
 [tox]
-envlist = py27, py36, flake8
+envlist = py27, py37, flake8
 
 [testenv]
-setenv = PATH = {toxinidir}/node_modules/.bin:$PATH
+setenv =
+    PATH={toxinidir}/node_modules/.bin{:}{envbindir}{:}{env:PATH}
 deps = -rrequirements_dev.txt
-whitelist_externals = npm
+whitelist_externals = env npm
 commands_pre = npm install --no-save jsdoc@3.6.3 typedoc@0.15.0
-commands = pytest -vv
+# Contrary to the tox docs, setenv's changes to $PATH are not visible inside
+# any commands we call. I hack around this with env:
+commands =
+    env PATH={env:PATH} pytest -vv
 
 [testenv:flake8]
 # Pinned so new checks aren't added by surprise:


### PR DESCRIPTION
This way, the versions of jsdoc and typdoc we're testing against are consistent, and we don't have to document so much.