### PR TITLE
Add LICENSE to distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 recursive-include sphinx_js/templates *.rst
-
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal = 1
+
+[metadata]
+license_files = LICENSE


### PR DESCRIPTION
Thanks for the great tool!

This adds the LICENSE to the tarball and wheel outputs.

Motivation: looking to package this for conda-forge (which requires licenses be included when the license in question demands it), which can neatly take care of the `nodejs` dependency, and potentially typedoc and jsdoc (though neatly packaging npm stuff is a bit more troublesome). I am having a bit of trouble with the `test_build` stuff, which dies with the `RuntimeError` under the versions available in conda without much feedback from the underlying sphinx call... still investigating!