### PR TITLE
extend typename of typeParameter with constraint

### DIFF
--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -145,7 +145,7 @@ class TypeDoc(object):
             names = [type.get('name')]
             constraint = type.get('constraint')
             if constraint is not None:
-                names.extend(['extends', self.make_type_name(constraint)])
+                names.extend(['extends'] + self.make_type_name(constraint))
         elif type.get('type') == 'reflection':
             names = ['<TODO>']
         if type.get('typeArguments'):


### PR DESCRIPTION
> Dupe of #119, probably: feel free to close!

Here's [a fun one](https://github.com/jupyterlab/jupyterlab/blob/bb21bc71085413e14044cdf8aabd08f3126fc76f/packages/application/src/frontend.ts#L185)... yields:

```
# Sphinx version: 2.2.1
# Python version: 3.7.3 (CPython)
# Docutils version: 0.15.2 release
# Jinja2 version: 2.10.3

# typedoc: 0.15.2  # added by me

# Last messages:

Exception occurred:
  File ".../sphinx_js/typedoc.py", line 152, in <listcomp>
    argNames = ['|'.join(self.make_type_name(arg)) for arg in type.get('typeArguments')]
TypeError: sequence item 2: expected str instance, list found
```
(nothing much else in the log)

it appears that `make_type_name` is always expected to return a `List[Text]`: this change ensures a `typeParameter` with a constraint does not become `List[Union[Text, List[Text]]`... or worse! I see some of them are having the `0`th item taken, would that be more appropriate?

Happy to work up a test... i see there are some ts files that are getting round-tripped, which includes a pretty gnarly generic, as well as a build example... what would be most beneficial to add?

However, I can't claim to have gotten all the way down the rabbit hole due to our use of lerna, and trying to make [typedoc-plugin-lerna-packages](https://github.com/marcj/typedoc-plugin-lerna-packages) work as well... my environment is kind of a mess of hacks right now.
