### PR TITLE
Enable the CI for py35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
       - npm
 python:
   - "2.7"
+  - "3.5"
   - "3.7"
 
 matrix:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py37, flake8
+envlist = py27, py35, py37, flake8
 
 [testenv]
 setenv =


### PR DESCRIPTION
This is the Python version used by Firefox CI