### PR TITLE
Fix a weird error when pointing js_source_paths directly to TypeScript files

### DIFF
--- a/sphinx_js/doclets.py
+++ b/sphinx_js/doclets.py
@@ -196,7 +196,7 @@ def doclet_full_path(d, base_dir, longname_field='longname'):
         for the long name of the object to emit a path to
     """
     meta = d['meta']
-    rel = relpath(meta['path'], base_dir)
+    rel = relpath(os.path.join(base_dir, meta['path']), base_dir)
     rel = '/'.join(rel.split(sep))
     if not rel.startswith(('../', './')) and rel not in ('..', '.'):
         # It just starts right out with the name of a folder in the cwd.

--- a/tests/test_build_ts_direct_source_paths/source/class.ts
+++ b/tests/test_build_ts_direct_source_paths/source/class.ts
@@ -1,0 +1,29 @@
+/**
+ * A definition of a class
+ */
+class ClassDefinition {
+    field: string;
+
+    /**
+     * ClassDefinition constructor
+     * @param simple A parameter with a simple type
+     */
+    constructor(simple: number) {
+
+    }
+
+    /**
+     * This is a method without return type
+     * @param simple A parameter with a simple type
+     */
+    method1(simple: number) : void {
+
+    }
+
+    /**
+     * This is a method (should be before method 'method1', but after fields)
+     */
+    anotherMethod() {
+
+    }
+}

--- a/tests/test_build_ts_direct_source_paths/source/docs/autoclass_star.rst
+++ b/tests/test_build_ts_direct_source_paths/source/docs/autoclass_star.rst
@@ -1,0 +1,2 @@
+.. js:autoclass:: ClassDefinition
+   :members: method1, *

--- a/tests/test_build_ts_direct_source_paths/source/docs/conf.py
+++ b/tests/test_build_ts_direct_source_paths/source/docs/conf.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+extensions = [
+    'sphinx_js'
+]
+
+# Minimal stuff needed for Sphinx to work:
+source_suffix = '.rst'
+master_doc = 'index'
+author = u'Erik Rose'
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+jsdoc_config_path = '../tsconfig.json'
+js_source_path = '../class.ts'
+js_language = 'typescript'

--- a/tests/test_build_ts_direct_source_paths/source/docs/index.rst
+++ b/tests/test_build_ts_direct_source_paths/source/docs/index.rst
@@ -1,0 +1,2 @@
+.. js:autoclass:: ClassDefinition
+   :members:

--- a/tests/test_build_ts_direct_source_paths/source/tsconfig.json
+++ b/tests/test_build_ts_direct_source_paths/source/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "compilerOptions": {
+      "target": "es6",
+      "module": "commonjs",
+      "moduleResolution": "node"
+    }
+  }

--- a/tests/test_build_ts_direct_source_paths/test_build_ts_direct_source_paths.py
+++ b/tests/test_build_ts_direct_source_paths/test_build_ts_direct_source_paths.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from tests.testing import SphinxBuildTestCase
+
+
+class Tests(SphinxBuildTestCase):
+    """Tests which require our one big Sphinx tree to be built (typescript version)"""
+
+    def test_autoclass_constructor(self):
+        """Make sure class constructor comes before methods."""
+        contents = self._file_contents('index')
+        pos_cstrct = contents.index('ClassDefinition constructor')
+        pos_method = contents.index('ClassDefinition.method1')
+        assert pos_method > pos_cstrct, 'Constructor appears after method in ' + contents
+
+    def test_autoclass_order(self):
+        """Make sure fields come before methods."""
+        contents = self._file_contents('index')
+        pos_field = contents.index('ClassDefinition.field')
+        pos_method2 = contents.index('ClassDefinition.anotherMethod')
+        pos_method = contents.index('ClassDefinition.method1')
+        assert pos_field < pos_method2 < pos_method, 'Methods and fields are not in right order in ' + contents
+
+    def test_autoclass_star_order(self):
+        """Make sure fields come before methods even when using ``*``."""
+        contents = self._file_contents('autoclass_star')
+        pos_method = contents.index('ClassDefinition.method1')
+        pos_field = contents.index('ClassDefinition.field')
+        pos_method2 = contents.index('ClassDefinition.anotherMethod')
+        assert pos_method < pos_field < pos_method2, 'Methods and fields are not in right order in ' + contents


### PR DESCRIPTION
I'm not super confident in this fix, but it passes existing tests, so maybe it's fine :P

The problem here happens when specifying TypeScript source files directly in `js_source_paths` instead of a folder. The added test is a copy of the existing `test_build_ts`, but in `conf.py` I specify `js_source_path = '../class.ts'`. This is enough to trigger the problem.

The resulting doclets confuse the path parsing logic. Here's an example doclet and error from the project I was working on when I ran into this:

`{'kind': 'module', 'comment': '<empty>', 'meta': {'path': './', 'filename': 'index.ts', 'lineno': 1, 'code': {}}, 'name': '"index"', 'longname': 'module:index', 'description': ''}`

And error (modified to show larger context):

```
# Sphinx version: 2.2.0
# Python version: 3.7.4 (CPython)
# Docutils version: 0.16 release
# Jinja2 version: 2.11.1
# Last messages:

# Loaded extensions:
Traceback (most recent call last):
  File "/venv/lib/python3.7/site-packages/sphinx/cmd/build.py", line 275, in build_main
    args.tags, args.verbosity, args.jobs, args.keep_going)
  File "/venv/lib/python3.7/site-packages/sphinx/application.py", line 269, in __init__
    self._init_builder()
  File "/venv/lib/python3.7/site-packages/sphinx/application.py", line 330, in _init_builder
    self.events.emit('builder-inited')
  File "/venv/lib/python3.7/site-packages/sphinx/events.py", line 103, in emit
    results.append(callback(self.app, *args))
  File "/venv/lib/python3.7/site-packages/sphinx_js/doclets.py", line 45, in gather_doclets
    doclet_full_path(d, root_for_relative_paths),
  File "/venv/lib/python3.7/site-packages/sphinx_js/doclets.py", line 219, in doclet_full_path
    path_and_formal_params['path'].parse(path))
  File "/venv/lib/python3.7/site-packages/parsimonious/expressions.py", line 110, in parse
    node = self.match(text, pos=pos)
  File "/venv/lib/python3.7/site-packages/parsimonious/expressions.py", line 127, in match
    raise error
parsimonious.exceptions.ParseError: Rule 'path' didn't match at '../../../doc/index.module:index' (line 1, column 1).
```