### PR TITLE
Support constraints in type parameters

### DIFF
--- a/tests/typescript/class.ts.jsdoc
+++ b/tests/typescript/class.ts.jsdoc
@@ -273,9 +273,7 @@
                 "name": "union",
                 "type": {
                     "names": [
-                        "number",
-                        "string",
-                        "any"
+                        "number|string|any"
                     ]
                 }
             }
@@ -286,9 +284,7 @@
                 "name": "method3",
                 "type": {
                     "names": [
-                        "number",
-                        "string",
-                        "any"
+                        "number|string|any"
                     ]
                 }
             }

--- a/tests/typescript/generic-constraint.ts
+++ b/tests/typescript/generic-constraint.ts
@@ -1,0 +1,23 @@
+interface A {
+    a: number;
+}
+
+interface B {
+    b: number;
+}
+
+/**
+ * Generic class with a type constraint
+ * @param T Type extending A
+ */
+class GenericConstraint<T extends A> {
+    t: T;
+
+    /**
+     * A generic method with a type constraint
+     * @param arg An argument of type U
+     */
+    method<U extends B>(arg: U) {
+        return arg;
+    };
+}

--- a/tests/typescript/generic-constraint.ts.jsdoc
+++ b/tests/typescript/generic-constraint.ts.jsdoc
@@ -1,0 +1,172 @@
+[
+    {
+        "comment": "<empty>",
+        "description": "",
+        "kind": "external",
+        "longname": "external:generic-constraint",
+        "meta": {
+            "code": {},
+            "filename": "generic-constraint.ts",
+            "lineno": 1,
+            "path": "./"
+        },
+        "name": "\"generic-constraint\""
+    },
+    {
+        "classdesc": "",
+        "comment": "<empty>",
+        "description": "Generic class with a type constraint\n\n",
+        "extends": [],
+        "kind": "class",
+        "longname": "external:generic-constraint~GenericConstraint",
+        "memberof": "external:generic-constraint",
+        "meta": {
+            "code": {},
+            "filename": "generic-constraint.ts",
+            "lineno": 13,
+            "path": "./"
+        },
+        "name": "GenericConstraint",
+        "params": [
+            {
+                "description": "Type extending A\n\n\n",
+                "name": "T",
+                "type": {
+                    "names": [
+                        "generic-constraint.A"
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "<empty>",
+        "description": "",
+        "kind": "member",
+        "longname": "external:generic-constraint~GenericConstraint#t",
+        "memberof": "external:generic-constraint~GenericConstraint",
+        "meta": {
+            "code": {},
+            "filename": "generic-constraint.ts",
+            "lineno": 14,
+            "path": "./"
+        },
+        "name": "t",
+        "type": {
+            "names": [
+                "T extends generic-constraint.A"
+            ]
+        }
+    },
+    {
+        "comment": "<empty>",
+        "description": "A generic method with a type constraint\n\n",
+        "kind": "function",
+        "longname": "external:generic-constraint~GenericConstraint.method",
+        "memberof": "external:generic-constraint~GenericConstraint",
+        "meta": {
+            "code": {
+                "paramnames": [
+                    "arg"
+                ]
+            },
+            "filename": "generic-constraint.ts",
+            "lineno": 20,
+            "path": "./"
+        },
+        "name": "method",
+        "params": [
+            {
+                "description": "\n\nAn argument of type U\n",
+                "name": "arg",
+                "type": {
+                    "names": [
+                        "U extends generic-constraint.B"
+                    ]
+                }
+            }
+        ],
+        "returns": [
+            {
+                "name": "method",
+                "type": {
+                    "names": [
+                        "U"
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "classdesc": "*interface*",
+        "comment": "<empty>",
+        "description": "",
+        "extends": [],
+        "kind": "interface",
+        "longname": "external:generic-constraint~A",
+        "memberof": "external:generic-constraint",
+        "meta": {
+            "code": {},
+            "filename": "generic-constraint.ts",
+            "lineno": 1,
+            "path": "./"
+        },
+        "name": "A",
+        "params": []
+    },
+    {
+        "comment": "<empty>",
+        "description": "",
+        "kind": "member",
+        "longname": "external:generic-constraint~A#a",
+        "memberof": "external:generic-constraint~A",
+        "meta": {
+            "code": {},
+            "filename": "generic-constraint.ts",
+            "lineno": 2,
+            "path": "./"
+        },
+        "name": "a",
+        "type": {
+            "names": [
+                "number"
+            ]
+        }
+    },
+    {
+        "classdesc": "*interface*",
+        "comment": "<empty>",
+        "description": "",
+        "extends": [],
+        "kind": "interface",
+        "longname": "external:generic-constraint~B",
+        "memberof": "external:generic-constraint",
+        "meta": {
+            "code": {},
+            "filename": "generic-constraint.ts",
+            "lineno": 5,
+            "path": "./"
+        },
+        "name": "B",
+        "params": []
+    },
+    {
+        "comment": "<empty>",
+        "description": "",
+        "kind": "member",
+        "longname": "external:generic-constraint~B#b",
+        "memberof": "external:generic-constraint~B",
+        "meta": {
+            "code": {},
+            "filename": "generic-constraint.ts",
+            "lineno": 6,
+            "path": "./"
+        },
+        "name": "b",
+        "type": {
+            "names": [
+                "number"
+            ]
+        }
+    }
+]


### PR DESCRIPTION
We're considering sphinx-js as the documentation solution for https://github.com/projectfluent/fluent.js which is written in TypeScript. I quickly ran into #119 and here's my attempt to fix it.

I looked at the recursive approach from https://github.com/graup/sphinx-js/commit/4def189dc364f9c5a24331ae4dc7a4181abb75d5 and the other fix proposed in #124. My fix is closer to #124 except that I also went ahead and changed the return value of `make_type_name` from list to a string. It's because as far as I was able to tell, all code paths except for one return a one-element list anyways anyways.

The only case where the list can have more than one element on master is when the type is a union. I think it would actually be better to return a string for unions too, given what how other types are handled. I suspect that the current list-returning behavior is why this line was required: https://github.com/mozilla/sphinx-js/blob/404c72d01d080a228335c508c330eca0e6e6b288/sphinx_js/typedoc.py#L137

Please let me know if my assumptions are off. They're based on reading the code, the [JSDoc schema](https://github.com/jsdoc/jsdoc/blob/master/packages/jsdoc/lib/jsdoc/schema.js) and the [TypeDoc API docs](https://typedoc.org/api/interfaces/typeobject.html#name). I'm sure there's more context which I'm not aware of.