### PR TITLE
Fix tox.ini on Windows

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands_pre = npm install --no-save jsdoc@3.6.3 typedoc@0.15.0
 # Contrary to the tox docs, setenv's changes to $PATH are not visible inside
 # any commands we call. I hack around this with env:
 commands =
-    env PATH={env:PATH} pytest -vv
+    env PATH="{env:PATH}" pytest -vv
 
 [testenv:flake8]
 # Pinned so new checks aren't added by surprise:

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,9 @@ envlist = py27, py37, flake8
 setenv =
     PATH={toxinidir}/node_modules/.bin{:}{envbindir}{:}{env:PATH}
 deps = -rrequirements_dev.txt
-whitelist_externals = env npm
+whitelist_externals =
+  env
+  npm
 commands_pre = npm install --no-save jsdoc@3.6.3 typedoc@0.15.0
 # Contrary to the tox docs, setenv's changes to $PATH are not visible inside
 # any commands we call. I hack around this with env:


### PR DESCRIPTION
Here are two small fixes I had to make to make `tox` work on my machine (Windows 10 with WSL):

- On Windows (and WSL) the PATH variable may contain spaces, e.g. "/c/Program Files".
- According to Tox docs](https://tox.readthedocs.io/en/latest/config.html#conf-whitelist_externals), the value of `whitelist_externals` should be given over multiple lines if there's more external than one.