### PR TITLE
Use app.srcdir for resolving files

### DIFF
--- a/sphinx_js/__init__.py
+++ b/sphinx_js/__init__.py
@@ -44,9 +44,9 @@ def analyze(app):
     away its results in a language-specific Analyzer."""
     # Normalize config values:
     source_paths = [app.config.js_source_path] if isinstance(app.config.js_source_path, str) else app.config.js_source_path
-    abs_source_paths = [normpath(join(app.confdir, path)) for path in source_paths]
+    abs_source_paths = [normpath(join(app.srcdir, path)) for path in source_paths]
     root_for_relative_paths = root_or_fallback(
-        normpath(join(app.confdir, app.config.root_for_relative_js_paths)) if app.config.root_for_relative_js_paths else None,
+        normpath(join(app.srcdir, app.config.root_for_relative_js_paths)) if app.config.root_for_relative_js_paths else None,
         abs_source_paths)
 
     # Pick analyzer:


### PR DESCRIPTION
`app.confdir` is just the folder containing the `conf.py` file and this is not necessarily the folder where the doc sources are. Incidentally using `confdir` also breaks [sphinx-multiversion](https://pypi.org/project/sphinx-multiversion/) as that specifically re-uses `conf.py` across all the doc builds by making use of sphinx' `-c` command line argument to specify the folder containing the `conf.py` file.