### PR TITLE
bugfix @see tag does not work with static function/member

### DIFF
--- a/sphinx_js/__init__.py
+++ b/sphinx_js/__init__.py
@@ -1,6 +1,9 @@
 from os.path import join, normpath
 
+from sphinx.domains.javascript import JavaScriptDomain
+from sphinx.domains import ObjType
 from sphinx.errors import SphinxError
+from sphinx.locale import _
 
 from .directives import (auto_class_directive_bound_to_app,
                          auto_function_directive_bound_to_app,
@@ -30,6 +33,12 @@ def setup(app):
                                 'autoattribute',
                                 auto_attribute_directive_bound_to_app(app))
     # TODO: We could add a js:module with app.add_directive_to_domain().
+
+    # NOTE: I couldn't find a recommended/denoted way to add a new object type
+    # to a specific domain. When using the app.add_object_type() method it is not
+    # possible to reference namespace objects 'cause sphinx adds the object to
+    # the 'std' domain a not the 'js' domain.
+    JavaScriptDomain.object_types.setdefault('staticfunction', ObjType(_('static function'), 'func'))
 
     app.add_config_value('js_language', 'javascript', 'env')
     app.add_config_value('js_source_path', '../', 'env')


### PR DESCRIPTION
Using JSDocs ``@see`` tag to reference a static function/member causes Sphinx to crash with the following error message

![image](https://user-images.githubusercontent.com/34922647/117941842-c325a080-b30a-11eb-9322-3feecf3fd8a6.png)

Since we've added the directive ``js:staticfunction`` we also have to specify a new object type within the JS Domain that allows Sphinx to resolve the any reference.

This example code works now:
```js
    /**
     * SomeMembers
     */
    class SomeMembers {
        /**
        * Some static member.
        *
        * @returns {void}
        */
        static someStaticMember() {
            // No use of this
        }

        /**
        * Non-static member
        *
        * @see someStaticMember
        * @returns {void}
        */
        nonStaticMember() {
            this.nonStatic = true;
        }
    }
```

It's also possible to reference a static function/member by using the ``js:func:`` role 

```code
    :js:func:`SomeMembers.someStaticMember`
```

Unfortunately, there is no way extend Sphinx to define the correct index text for static functions.

See sphinx.domains.javascript.py code snippet
```python
def get_index_text(self, objectname: str, name_obj: Tuple[str, str]) -> str:
    name, obj = name_obj
    if self.objtype == 'function':
        if not obj:
            return _('%s() (built-in function)') % name
        return _('%s() (%s method)') % (name, obj)
    elif self.objtype == 'class':
        return _('%s() (class)') % name
    elif self.objtype == 'data':
        return _('%s (global variable or constant)') % name
    elif self.objtype == 'attribute':
        return _('%s (%s attribute)') % (name, obj)
    return ''
```

Unless we generate a JS index, we may not notice any restriction...
What do you think??
