### PR TITLE
Allow py39+ compatible `parsimonious` version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(exclude=['ez_setup']),
     url='https://github.com/mozilla/sphinx-js',
     include_package_data=True,
-    install_requires=['Jinja2>2.0,<3.0', 'parsimonious>=0.7.0,<0.8.0', 'Sphinx>=3.0.0'],
+    install_requires=['Jinja2>2.0,<3.0', 'parsimonious>=0.7.0,<0.9.0', 'Sphinx>=3.0.0'],
     python_requires='>=3.7',
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
Currently, the users of sphinx-js will only be able to get parsimonious v0.7.0 which is about
5 years old and does not support Python 3.9 or higher. The newer versions of the 0.8.x
stream fix the compatibility issues and are necessary `sphinx-js` to be usable under
Python 3.10 and Python 3.9.