### PR TITLE
update Jinja2

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,4 +3,4 @@ recommonmark==0.7.1
 # Sphinx's plain-text renderer changes behavior slightly
 # with regard to how it emits class names and em dashes from
 # time to time:
-Sphinx==3.5.4
+Sphinx==4.1.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(exclude=['ez_setup']),
     url='https://github.com/mozilla/sphinx-js',
     include_package_data=True,
-    install_requires=['Jinja2>2.0,<3.0', 'parsimonious>=0.7.0,<0.8.0', 'Sphinx>=3.0.0'],
+    install_requires=['Jinja2>3.0,<4.0', 'parsimonious>=0.7.0,<0.8.0', 'Sphinx>=3.0.0'],
     python_requires='>=3.7',
     classifiers=[
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(exclude=['ez_setup']),
     url='https://github.com/mozilla/sphinx-js',
     include_package_data=True,
-    install_requires=['Jinja2==3.1.1', 'parsimonious==0.9.0', 'Sphinx==4.5.0'],
+    install_requires=['Jinja2==3.1.1', 'parsimonious==0.9.0', 'Sphinx==4.1.0'],
     python_requires='>=3.7',
     classifiers=[
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(exclude=['ez_setup']),
     url='https://github.com/mozilla/sphinx-js',
     include_package_data=True,
-    install_requires=['Jinja2>3.0,<4.0', 'parsimonious>=0.9.0,<0.10.0', 'Sphinx>=4.0.0,<5.0.0'],
+    install_requires=['Jinja2==3.1.1', 'parsimonious==0.9.0', 'Sphinx==4.5.0'],
     python_requires='>=3.7',
     classifiers=[
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(exclude=['ez_setup']),
     url='https://github.com/mozilla/sphinx-js',
     include_package_data=True,
-    install_requires=['Jinja2>3.0,<4.0', 'parsimonious>=0.7.0,<0.8.0', 'Sphinx>=3.0.0'],
+    install_requires=['Jinja2>3.0,<4.0', 'parsimonious>=0.7.0,<0.8.0', 'Sphinx>=4.0.0,<5.0.0'],
     python_requires='>=3.7',
     classifiers=[
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(exclude=['ez_setup']),
     url='https://github.com/mozilla/sphinx-js',
     include_package_data=True,
-    install_requires=['Jinja2>3.0,<4.0', 'parsimonious>=0.7.0,<0.8.0', 'Sphinx>=4.0.0,<5.0.0'],
+    install_requires=['Jinja2>3.0,<4.0', 'parsimonious>=0.9.0,<0.10.0', 'Sphinx>=4.0.0,<5.0.0'],
     python_requires='>=3.7',
     classifiers=[
         'Intended Audience :: Developers',

--- a/sphinx_js/directives.py
+++ b/sphinx_js/directives.py
@@ -9,6 +9,7 @@ can access each other and collaborate.
 """
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives import flag
+from sphinx import addnodes
 from sphinx.domains.javascript import JSCallable
 
 from .renderers import (AutoFunctionRenderer,
@@ -90,4 +91,7 @@ def _members_to_exclude(arg):
 
 class JSStaticFunction(JSCallable):
     """Like a callable but with a different prefix."""
-    display_prefix = 'static '
+
+    def get_display_prefix(self):
+        return [addnodes.desc_sig_keyword('static', 'static'),
+                addnodes.desc_sig_space()]

--- a/tests/test_build_js/source/code.js
+++ b/tests/test_build_js/source/code.js
@@ -243,5 +243,5 @@ class SimpleClass {
     /**
      * Static.
      */
-    static noUseOfThis() {}
+    static aStaticClassFunction() {}
 }

--- a/tests/test_build_js/test_build_js.py
+++ b/tests/test_build_js/test_build_js.py
@@ -49,7 +49,10 @@ class Tests(SphinxBuildTestCase):
         """Make sure @callback uses can be documented with autofunction."""
         self._file_contents_eq(
             'autofunction_callback',
-            u'requestCallback(responseCode)\n\n   Some global callback\n\n   Arguments:\n      * **responseCode** (*number*) --\n')
+            u'requestCallback(responseCode)\n\n'
+            '   Some global callback\n\n'
+            '   Arguments:\n'
+            '      * **responseCode** (*number*) --\n')
 
     def test_autofunction_example(self):
         """Make sure @example tags can be documented with autofunction."""

--- a/tests/test_build_js/test_build_js.py
+++ b/tests/test_build_js/test_build_js.py
@@ -43,7 +43,9 @@ class Tests(SphinxBuildTestCase):
         """Make sure @typedef uses can be documented with autofunction."""
         self._file_contents_eq(
             'autofunction_typedef',
-            u'TypeDefinition()\n\n   Arguments:\n      * **width** (*Number*) -- width in pixels\n')
+            u'TypeDefinition()\n\n'
+            '   Arguments:\n'
+            '      * **width** (*Number*) -- width in pixels\n')
 
     def test_autofunction_callback(self):
         """Make sure @callback uses can be documented with autofunction."""

--- a/tests/test_build_js/test_build_js.py
+++ b/tests/test_build_js/test_build_js.py
@@ -131,7 +131,7 @@ class Tests(SphinxBuildTestCase):
             'class SimpleClass()\n\n'
             '   Class doc.\n'
             '\n'
-            '   static SimpleClass.noUseOfThis()\n'
+            '   static SimpleClass.aStaticClassFunction()\n'
             '\n'
             '      Static.\n')
 

--- a/tests/test_jsdoc_analysis/test_jsdoc.py
+++ b/tests/test_jsdoc_analysis/test_jsdoc.py
@@ -86,7 +86,7 @@ class ClassTests(JsDocTestCase):
         assert cls.filename == 'class.js'
         assert cls.description == 'This is a long description that should not be unwrapped. Once day, I was\nwalking down the street, and a large, green, polka-dotted grand piano fell\nfrom the 23rd floor of an apartment building.'
         assert cls.line == 8
-        assert cls.examples == ['Example in constructor']  # We ignore examples and other fields from the class doclet so far. This could change someday.
+        assert cls.examples == ['Example in class']  # We ignore examples and other fields from the class doclet so far. This could change someday.
 
         # Members:
         getter, private_method = cls.members  # default constructor not included here

--- a/tests/test_jsdoc_analysis/test_jsdoc.py
+++ b/tests/test_jsdoc_analysis/test_jsdoc.py
@@ -85,7 +85,7 @@ class ClassTests(JsDocTestCase):
         assert cls.path == Pathname(['./', 'class.', 'Foo'])
         assert cls.filename == 'class.js'
         assert cls.description == 'This is a long description that should not be unwrapped. Once day, I was\nwalking down the street, and a large, green, polka-dotted grand piano fell\nfrom the 23rd floor of an apartment building.'
-        assert cls.line == 15  # Not ideal, as it refers to the constructor, but we'll allow it
+        assert cls.line == 8
         assert cls.examples == ['Example in constructor']  # We ignore examples and other fields from the class doclet so far. This could change someday.
 
         # Members:

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands_pre = npm install --no-save jsdoc@3.6.3 typedoc@0.15.0
 # Contrary to the tox docs, setenv's changes to $PATH are not visible inside
 # any commands we call. I hack around this with env:
 commands =
-    env PATH="{env:PATH}" pytest -vv
+    env PATH="{env:PATH}" pytest -vv {posargs}
 
 [testenv:flake8]
 # Pinned so new checks aren't added by surprise:


### PR DESCRIPTION
Markup, a unpinned dependency of Jinja2, decided to remove a deprecated function that Jinja relied on, causing Jinja2 to throw an error sometime in Feb 2020.

Jinja2 has upgraded and recommends affected users upgrade rather than pinning an old version of Markup. 

This PR incorporates that update into sphinx-js