### PR TITLE
replace yield StopItertion with return

### DIFF
--- a/sphinx_js/typedoc.py
+++ b/sphinx_js/typedoc.py
@@ -63,7 +63,7 @@ class Analyzer:
             node = node.get('__parent')
             if not node or node['id'] == 0:
                 # We went all the way up but didn't find a containing module.
-                yield StopIteration
+                return
             elif node.get('kindString') == 'External module':
                 # Found one!
                 yield node


### PR DESCRIPTION
this should have always been `raise StopIteration`, but even that does not work properly in python 3.6 and higher becuase of PEP 479, which recommends replacing `raise StopIteration` with `return`

fixes issue #199