### PR TITLE
Update dependencies for python 3.10 compat and fix an exception

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(exclude=['ez_setup']),
     url='https://github.com/mozilla/sphinx-js',
     include_package_data=True,
-    install_requires=['Jinja2>2.0,<3.0', 'markupsafe==2.0.1', 'parsimonious>=0.7.0,<0.8.0', 'Sphinx>=3.0.0'],
+    install_requires=['Jinja2>2.0,<3.0', 'markupsafe==2.0.1', 'parsimonious~=0.8.0', 'Sphinx>=3.0.0'],
     python_requires='>=3.7',
     classifiers=[
         'Intended Audience :: Developers',

--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -86,7 +86,7 @@ class JsRenderer(object):
             if obj.deppath:
                 return set([obj.deppath])
         except SphinxError as exc:
-            logger.exception('Exception while retrieving paths for IR object "%s"' % (''.join(exc.segments)))
+            logger.exception('Exception while retrieving paths for IR object: %s' % exc)
         return set([])
 
     def rst_nodes(self):


### PR DESCRIPTION
Sorry, two changes in one...

- parsimonious 0.7.0 doesn't work with Python 3.10 (fixes https://github.com/mozilla/sphinx-js/issues/186)
- trying to report an exception in `JsRenderer.dependencies` causes an exception because the exception isn't the exception we're looking for