### PR TITLE
fix: get_object() does not raise a SuffixError

### DIFF
--- a/sphinx_js/renderers.py
+++ b/sphinx_js/renderers.py
@@ -86,7 +86,7 @@ class JsRenderer(object):
             if obj.deppath:
                 return set([obj.deppath])
         except SphinxError as exc:
-            logger.exception('Exception while retrieving paths for IR object "%s"' % (''.join(exc.segments)))
+            logger.exception('Exception while retrieving paths for IR object: %s' % exc)
         return set([])
 
     def rst_nodes(self):


### PR DESCRIPTION
The exception here *will not* have a `segments` attribute because it is a plain SphinxError and not a SuffixError (see a few lines higher up in get_object())