### PR TITLE
run multiple versions of python 3.x in CI and Tox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,11 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
+
+    continue-on-error: true
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     name: Python ${{ matrix.python-version}}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,13 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9']
+        experimental: [false]
+        include:
+          - python-version: '3.10'
+            experimental: true
+          - python-version: '3.11'
+            experimental: true
 
     name: Python ${{ matrix.python-version}}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,6 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9']
         experimental: [false]
-        include:
-          - python-version: '3.10'
-            experimental: true
-          - python-version: '3.11'
-            experimental: true
 
     name: Python ${{ matrix.python-version}}
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310
+envlist = py37, py38, py39, py310, py311
 
 [gh-actions]
 python =
@@ -7,6 +7,7 @@ python =
   3.8: py38
   3.9: py39
   3.10: py310
+  3.11: py311
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, flake8
+envlist = py37, py38, py39, py310
 
 [gh-actions]
 python =


### PR DESCRIPTION
Tox has only been wired up to run 3.9 in CI

This expands CI coverage to supported version of Python