### PR TITLE
restore python versions 3.10 and 3.11 in the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9']
         experimental: [false]
+        include:
+          - python-version: '3.10'
+            experimental: true
+          - python-version: '3.11'
+            experimental: true
 
     name: Python ${{ matrix.python-version}}
     steps:


### PR DESCRIPTION
This reverts commit 17e2ca156a9461dc680616ac0915f6e1ebbb231d and restores 3.10 and 3.11 to the test matrix. At the time this is opened, these are expected to fail and should not be merged until they are passing.

For more context, see: https://github.com/mozilla/sphinx-js/pull/207

