### PR TITLE
fixes sphinx-js with sphinx 4.1.0+ (#209, #203)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,15 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         experimental: [false]
 
     name: Python ${{ matrix.python-version}}
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v3.1.0
 
       - name: Set up Python
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pytest==6.2.3
+pytest==7.2.0
 recommonmark==0.7.1
 # Sphinx's plain-text renderer changes behavior slightly
 # with regard to how it emits class names and em dashes from
@@ -6,4 +6,4 @@ recommonmark==0.7.1
 Sphinx==3.5.4
 markupsafe==2.0.1
 Jinja2>2.0,<3.0
-
+tox==4.0.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,9 +1,5 @@
+-e .
+
 pytest==7.2.0
 recommonmark==0.7.1
-# Sphinx's plain-text renderer changes behavior slightly
-# with regard to how it emits class names and em dashes from
-# time to time:
-Sphinx==3.5.4
-markupsafe==2.0.1
-Jinja2>2.0,<3.0
 tox==4.0.3

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,11 @@ setup(
     packages=find_packages(exclude=['ez_setup']),
     url='https://github.com/mozilla/sphinx-js',
     include_package_data=True,
-    install_requires=['Jinja2>2.0,<3.0', 'markupsafe==2.0.1', 'parsimonious>=0.9.0,<0.10.0', 'Sphinx>=3.0.0'],
+    install_requires=[
+        'Jinja2>2.0',
+        'parsimonious>=0.10.0,<0.11.0',
+        'Sphinx>=4.1.0,<6.0.0'
+    ],
     python_requires='>=3.7',
     classifiers=[
         'Intended Audience :: Developers',
@@ -24,6 +28,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Topic :: Documentation :: Sphinx',
         'Topic :: Software Development :: Documentation'
-        ],
+    ],
     keywords=['sphinx', 'documentation', 'docs', 'javascript', 'js', 'jsdoc', 'restructured', 'typescript', 'typedoc'],
 )

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ setup(
         'Jinja2>2.0',
         'parsimonious>=0.10.0,<0.11.0',
         'Sphinx>=4.1.0,<6.0.0'
+        # Pin markupsafe because of
+        # https://github.com/pallets/jinja/issues/1585
+        'markupsafe==2.0.1',
     ],
     python_requires='>=3.7',
     classifiers=[

--- a/sphinx_js/directives.py
+++ b/sphinx_js/directives.py
@@ -11,6 +11,7 @@ from os.path import join, relpath
 
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives import flag
+from sphinx import addnodes
 from sphinx.domains.javascript import JSCallable
 
 from .renderers import (AutoFunctionRenderer,
@@ -113,4 +114,6 @@ def _members_to_exclude(arg):
 
 class JSStaticFunction(JSCallable):
     """Like a callable but with a different prefix."""
-    display_prefix = 'static '
+    def get_display_prefix(self):
+        return [addnodes.desc_sig_keyword('static', 'static'),
+                addnodes.desc_sig_space()]

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,9 @@ python =
 setenv =
     PATH={toxinidir}/node_modules/.bin{:}{envbindir}{:}{env:PATH}
 deps = -rrequirements_dev.txt
-whitelist_externals =
-  env
-  npm
+allowlist_externals =
+    env
+    npm
 commands_pre = npm install --no-save jsdoc@3.6.3 typedoc@0.15.0
 # Contrary to the tox docs, setenv's changes to $PATH are not visible inside
 # any commands we call. I hack around this with env:


### PR DESCRIPTION
I had to fix some minor things before I was able to work on this, but the bulk of the PR is a workaround for [sphinx issue #11021](https://github.com/sphinx-doc/sphinx/issues/11021).

The gist of it is that this fixes the javascript domain `TypedField` and `GroupedField` to do what the python domain equivalents do--namely set `inliner` to `None` before calling `Field.make_xref`.

@lonnen's work finding the problematic commit in Sphinx was invaluable towards this fix. That made this so much easier than when I looked at it a year ago and bounced off it.

This also pulls in @lonnen's fix from PR #191 because that fixed a couple of tests that weren't working with whatever version of Sphinx I was testing with that was > 4.1.0.

The end result is that sphinx-js tests pass in Python 3.7 through 3.11 with Sphinx 4.10 through 5.3.0.

I thought about different ways to fix the problem. It's tricky because the bit we need to fix isn't very accessible. I tried to make this as minimal, but maintainable, as possible. If the comments are opaque, we should improve them. Future us will want present us to do that.

Pretty sure this fixes #209 and #203. It also replaces #191 and #208.