### PR TITLE
Fix Sphinx dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     install_requires=[
         'Jinja2>2.0',
         'parsimonious>=0.10.0,<0.11.0',
-        'Sphinx>=4.1.0,<6.0.0'
+        'Sphinx>=4.1.0,<6.0.0',
         # Pin markupsafe because of
         # https://github.com/pallets/jinja/issues/1585
         'markupsafe==2.0.1',


### PR DESCRIPTION
The missing comma causes the two strings to concatenate. This was a bug from PR #210. It's weird that it didn't get picked up in CI.