### PR TITLE
Add types to add_config_value("js_source_path") call (#182)

### DIFF
--- a/sphinx_js/__init__.py
+++ b/sphinx_js/__init__.py
@@ -92,9 +92,9 @@ def setup(app):
                                 auto_attribute_directive_bound_to_app(app))
     # TODO: We could add a js:module with app.add_directive_to_domain().
 
-    app.add_config_value('js_language', 'javascript', 'env')
-    app.add_config_value('js_source_path', '../', 'env')
-    app.add_config_value('jsdoc_config_path', None, 'env')
+    app.add_config_value('js_language', default='javascript', rebuild='env')
+    app.add_config_value('js_source_path', default=['../'], rebuild='env', types=[str, list])
+    app.add_config_value('jsdoc_config_path', default=None, rebuild='env')
 
     # We could use a callable as the "default" param here, but then we would
     # have had to duplicate or build framework around the logic that promotes


### PR DESCRIPTION
The `type` argument for add_config_value() defaults to `str`, but `js_source_path` takes a str or list of strings as a value, so this fixes that.

Firefox code: https://searchfox.org/mozilla-central/rev/3290b1740ff553305ee7378ee6d38b06b3979de7/docs/conf.py#54

Sphinx documentation: https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_config_value

Use in sphinx-js: https://github.com/mozilla/sphinx-js/blob/77b6cac1b168c0331c351ad05c0b9212320cc350/sphinx_js/__init__.py#L110

Fixes #182 and [bug 1734199](https://bugzilla.mozilla.org/show_bug.cgi?id=1734199).