### PR TITLE
Fixes objtype for staticfunction (#178)

### DIFF
--- a/tests/test_build_js/source/code.js
+++ b/tests/test_build_js/source/code.js
@@ -242,6 +242,15 @@ class SimpleClass {
 
     /**
      * Static.
+     *
+     * @see nonStaticMethod
      */
-    static noUseOfThis() {}
+    static staticMethod() {}
+
+    /**
+     * Non-static member.
+     *
+     * @see staticMethod
+     */
+    nonStaticMethod() {}
 }

--- a/tests/test_build_js/test_build_js.py
+++ b/tests/test_build_js/test_build_js.py
@@ -126,9 +126,21 @@ class Tests(SphinxBuildTestCase):
             'class SimpleClass()\n\n'
             '   Class doc.\n'
             '\n'
-            '   static SimpleClass.noUseOfThis()\n'
+            '   SimpleClass.nonStaticMethod()\n'
             '\n'
-            '      Static.\n')
+            '      Non-static member.\n'
+            '\n'
+            '      See also:\n'
+            '\n'
+            '        * "staticMethod"\n'
+            '\n'
+            '   static SimpleClass.staticMethod()\n'
+            '\n'
+            '      Static.\n'
+            '\n'
+            '      See also:\n'
+            '\n'
+            '        * "nonStaticMethod"\n')
 
     def test_autoclass(self):
         """Make sure classes show their class comment and constructor


### PR DESCRIPTION
This fixes the objtype xref when the thing is a staticfunction that was added to sphinx-js in pr #174.

Now `@see` should work and the index should show the right text.

This is based on work from @xsjad0 and obsoletes #178.