### PR TITLE
Update sphinx-quickstart tool output in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,29 +33,28 @@ Setup
         cd my-project
         sphinx-quickstart
 
-          > Root path for the documentation [.]: docs
+          Please enter values for the following settings (just press Enter to
+          accept a default value, if one is given in brackets).
+
+          Selected root path: .
+
+          You have two options for placing the build directory for Sphinx output.
+          Either, you use a directory "_build" within the root path, or you separate
+          "source" and "build" directories within the root path.
           > Separate source and build directories (y/n) [n]:
-          > Name prefix for templates and static dir [_]:
+
+          The project name will occur in several places in the built documentation.
           > Project name: My Project
           > Author name(s): Fred Fredson
-          > Project version []: 1.0
-          > Project release [1.0]:
+          > Project release []: 1.0
+
+          If the documents are to be written in a language other than English,
+          you can select a language here by its language code. Sphinx will then
+          translate text that it generates into that language.
+
+          For a list of supported codes, see
+          https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language.
           > Project language [en]:
-          > Source file suffix [.rst]:
-          > Name of your master document (without suffix) [index]:
-          > Do you want to use the epub builder (y/n) [n]:
-          > autodoc: automatically insert docstrings from modules (y/n) [n]:
-          > doctest: automatically test code snippets in doctest blocks (y/n) [n]:
-          > intersphinx: link between Sphinx documentation of different projects (y/n) [n]:
-          > todo: write "todo" entries that can be shown or hidden on build (y/n) [n]:
-          > coverage: checks for documentation coverage (y/n) [n]:
-          > imgmath: include math, rendered as PNG or SVG images (y/n) [n]:
-          > mathjax: include math, rendered in the browser by MathJax (y/n) [n]:
-          > ifconfig: conditional inclusion of content based on config values (y/n) [n]:
-          > viewcode: include links to the source code of documented Python objects (y/n) [n]:
-          > githubpages: create .nojekyll file to publish the document on GitHub pages (y/n) [n]:
-          > Create Makefile? (y/n) [y]:
-          > Create Windows command file? (y/n) [y]:
 
 4. In the generated Sphinx conf.py file, turn on ``sphinx_js`` by adding it to ``extensions``::
 


### PR DESCRIPTION
The README.md output is for an older version and they changed seemingly a lot in https://github.com/sphinx-doc/sphinx/issues/4148 . 

For instance, setting it up, I was a bit confused thinking I could select the documentation directory in the cli tool. Now instead, it conveniently auto-selects the root project directory `.` to put its files in.

This PR clarifies this a bit to match expectations for the tool output with the latest version.