### PR TITLE
Add Sphinx Extension PyPi classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     ],
     python_requires='>=3.7',
     classifiers=[
+        'Framework :: Sphinx :: Extension',
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Add the Sphinx Extension PyPi classifier so that the extension shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension).