### PR TITLE
Drop Sphinx upper-bound requirement (#227)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     install_requires=[
         'Jinja2>2.0',
         'parsimonious>=0.10.0,<0.11.0',
-        'Sphinx>=4.1.0,<6.0.0',
+        'Sphinx>=4.1.0',
         # Pin markupsafe because of
         # https://github.com/pallets/jinja/issues/1585
         'markupsafe==2.0.1',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 envlist =
-    py38
-    py39
-    py310
-    py311
+    py{38,39,310,311}-sphinx5
+    py{38,39,310,311}-sphinx6
+    py{38,39,310,311}-sphinx7
 
 [gh-actions]
 python =
@@ -15,7 +14,11 @@ python =
 [testenv]
 setenv =
     PATH={toxinidir}/node_modules/.bin{:}{envbindir}{:}{env:PATH}
-deps = -rrequirements_dev.txt
+deps =
+    -rrequirements_dev.txt
+    sphinx5: sphinx<6.0.0
+    sphinx6: sphinx<7.0.0
+    sphinx7: sphinx<8.0.0
 allowlist_externals =
     env
     npm


### PR DESCRIPTION
This drops the upper bound for the Sphinx requirement because I'm pretty sure we don't need it. We can fix issues as they come up and we aren't helped by having an upper bound.

This also reworks the matrix for tox.ini so that it tests with multiple versions of Sphinx.

Fixes #227