### PR TITLE
Update markupsafe pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         'Sphinx>=4.1.0',
         # Pin markupsafe because of
         # https://github.com/pallets/jinja/issues/1585
-        'markupsafe==2.0.1',
+        'markupsafe>=2.0.1',
     ],
     python_requires='>=3.8',
     classifiers=[


### PR DESCRIPTION
Currently sphinx-js pins the `markupsafe` to the exact version `2.0.1`. This can result in issues isntalling packages that depend on `sphinx-js` but also have dependencies that require newer versions of `markupsafe` (for example [werkzeug 3.0.x](https://github.com/pallets/werkzeug/blob/3.0.3/pyproject.toml#L23)).

Updating the pin to allow for versions `>=2.0.1` resolves this issue and does not appear to present obvious compatibility problems. The single version pin significantly limits the ability to use this tool in projects, and is inconsistent with the [other version specifications in setup.py](https://github.com/mozilla/sphinx-js/blob/master/setup.py#L15).