### PR TITLE
Fix yaml linting issue in ci.yml file and getting tests to run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
         experimental: [false]
 
     name: Python ${{ matrix.python-version}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,11 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - 'master'
   pull_request:
-    branches: [ master ]
+    branches:
+      - 'master'
 
 jobs:
   test:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         # https://github.com/pallets/jinja/issues/1585
         'markupsafe==2.0.1',
     ],
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     classifiers=[
         'Framework :: Sphinx :: Extension',
         'Intended Audience :: Developers',
@@ -28,7 +28,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: MIT License',
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/tests/roots/test-incremental_js/conf.py
+++ b/tests/roots/test-incremental_js/conf.py
@@ -5,7 +5,7 @@ extensions = [
 # Minimal stuff needed for Sphinx to work:
 source_suffix = '.rst'
 master_doc = 'index'
-author = u'Nick Alexander'
+author = 'Nick Alexander'
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 js_source_path = ['.', 'inner']
 root_for_relative_js_paths = '.'

--- a/tests/roots/test-incremental_ts/conf.py
+++ b/tests/roots/test-incremental_ts/conf.py
@@ -5,7 +5,7 @@ extensions = [
 # Minimal stuff needed for Sphinx to work:
 source_suffix = '.rst'
 master_doc = 'index'
-author = u'Nick Alexander'
+author = 'Nick Alexander'
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 js_language = 'typescript'
 js_source_path = ['.', 'inner']

--- a/tests/test_build_js/source/docs/conf.py
+++ b/tests/test_build_js/source/docs/conf.py
@@ -5,5 +5,5 @@ extensions = [
 # Minimal stuff needed for Sphinx to work:
 source_suffix = '.rst'
 master_doc = 'index'
-author = u'Erik Rose'
+author = 'Erik Rose'
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']

--- a/tests/test_build_js/test_build_js.py
+++ b/tests/test_build_js/test_build_js.py
@@ -1,4 +1,12 @@
+from sphinx import __version__ as sphinx_version
 from tests.testing import SphinxBuildTestCase
+
+
+SPHINX_VERSION = tuple(int(part) for part in sphinx_version.split('.'))
+
+# NOTE(willkg): This is the version of Sphinx that removes trailing " --" from
+# :params: lines when there is no description.
+SPHINX_7_3_0 = (7, 3, 0)
 
 
 class Tests(SphinxBuildTestCase):
@@ -47,9 +55,22 @@ class Tests(SphinxBuildTestCase):
 
     def test_autofunction_callback(self):
         """Make sure @callback uses can be documented with autofunction."""
-        self._file_contents_eq(
-            'autofunction_callback',
-            u'requestCallback(responseCode)\n\n   Some global callback\n\n   Arguments:\n      * **responseCode** (*number*) --\n')
+        if SPHINX_VERSION < SPHINX_7_3_0:
+            expected_content = (
+                'requestCallback(responseCode)\n\n'
+                '   Some global callback\n\n'
+                '   Arguments:\n'
+                '      * **responseCode** (*number*) --\n'
+            )
+        else:
+            expected_content = (
+                'requestCallback(responseCode)\n\n'
+                '   Some global callback\n\n'
+                '   Arguments:\n'
+                '      * **responseCode** (*number*)\n'
+            )
+
+        self._file_contents_eq('autofunction_callback', expected_content)
 
     def test_autofunction_example(self):
         """Make sure @example tags can be documented with autofunction."""
@@ -64,25 +85,48 @@ class Tests(SphinxBuildTestCase):
     def test_autofunction_destructured_params(self):
         """Make sure that all documented params appears in the function
         definition."""
-        self._file_contents_eq(
-            'autofunction_destructured_params',
-            u'destructuredParams(p1, p2)\n\n'
-            '   Arguments:\n'
-            '      * **p1** (*number*) --\n\n'
-            '      * **p2** (*Object*) --\n\n'
-            '      * **p2.foo** (*string*) --\n\n'
-            '      * **p2.bar** (*string*) --\n')
+        if SPHINX_VERSION < SPHINX_7_3_0:
+            expected_content = (
+                'destructuredParams(p1, p2)\n\n'
+                '   Arguments:\n'
+                '      * **p1** (*number*) --\n\n'
+                '      * **p2** (*Object*) --\n\n'
+                '      * **p2.foo** (*string*) --\n\n'
+                '      * **p2.bar** (*string*) --\n'
+            )
+        else:
+            expected_content = (
+                'destructuredParams(p1, p2)\n\n'
+                '   Arguments:\n'
+                '      * **p1** (*number*)\n\n'
+                '      * **p2** (*Object*)\n\n'
+                '      * **p2.foo** (*string*)\n\n'
+                '      * **p2.bar** (*string*)\n'
+            )
+
+        self._file_contents_eq('autofunction_destructured_params', expected_content)
 
     def test_autofunction_defaults_in_doclet(self):
         """Make sure param default values appear in the function definition,
         when defined in JSDoc."""
-        self._file_contents_eq(
-            'autofunction_defaults_doclet',
-            'defaultsDocumentedInDoclet(func=() => 5, str="a string with \\" quote", strNum="42", strBool="true", num=5, nil=null)\n\n'
-            '   Arguments:\n'
-            '      * **func** (*function*) --\n\n'
-            '      * **strNum** (*string*) --\n\n'
-            '      * **strBool** (*string*) --\n')
+        if SPHINX_VERSION < SPHINX_7_3_0:
+            expected_content = (
+                'defaultsDocumentedInDoclet(func=() => 5, str="a string with \\" quote", strNum="42", strBool="true", num=5, nil=null)\n\n'
+                '   Arguments:\n'
+                '      * **func** (*function*) --\n\n'
+                '      * **strNum** (*string*) --\n\n'
+                '      * **strBool** (*string*) --\n'
+            )
+        else:
+            expected_content = (
+                'defaultsDocumentedInDoclet(func=() => 5, str="a string with \\" quote", strNum="42", strBool="true", num=5, nil=null)\n\n'
+                '   Arguments:\n'
+                '      * **func** (*function*)\n\n'
+                '      * **strNum** (*string*)\n\n'
+                '      * **strBool** (*string*)\n'
+            )
+
+        self._file_contents_eq('autofunction_defaults_doclet', expected_content)
 
     def test_autofunction_defaults_in_code(self):
         """Make sure param default values appear in the function definition,
@@ -357,7 +401,7 @@ class Tests(SphinxBuildTestCase):
         switched from " | " as the union separator back to "|".
 
         """
-        assert '* **fnodeA** (*Node|Fnode*) --' in self._file_contents('union')
+        assert '* **fnodeA** (*Node|Fnode*)' in self._file_contents('union')
 
     def test_field_list_unwrapping(self):
         """Ensure the tails of field lists have line breaks and leading

--- a/tests/test_build_js/test_build_js.py
+++ b/tests/test_build_js/test_build_js.py
@@ -51,7 +51,7 @@ class Tests(SphinxBuildTestCase):
         """Make sure @typedef uses can be documented with autofunction."""
         self._file_contents_eq(
             'autofunction_typedef',
-            u'TypeDefinition()\n\n   Arguments:\n      * **width** (*Number*) -- width in pixels\n')
+            'TypeDefinition()\n\n   Arguments:\n      * **width** (*Number*) -- width in pixels\n')
 
     def test_autofunction_callback(self):
         """Make sure @callback uses can be documented with autofunction."""
@@ -383,7 +383,7 @@ class Tests(SphinxBuildTestCase):
         """
         self._file_contents_eq(
             'injection',
-            u'injection(a_, b)\n\n'
+            'injection(a_, b)\n\n'
             '   Arguments:\n'
             '      * **a_** -- Snorf\n\n'
             '      * **b** (*type_*) -- >>Borf_<<\n\n'

--- a/tests/test_build_ts/source/docs/conf.py
+++ b/tests/test_build_ts/source/docs/conf.py
@@ -5,7 +5,7 @@ extensions = [
 # Minimal stuff needed for Sphinx to work:
 source_suffix = '.rst'
 master_doc = 'index'
-author = u'Erik Rose'
+author = 'Erik Rose'
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 jsdoc_config_path = '../tsconfig.json'

--- a/tests/test_dot_dot_paths/source/docs/conf.py
+++ b/tests/test_dot_dot_paths/source/docs/conf.py
@@ -5,6 +5,6 @@ extensions = [
 # Minimal stuff needed for Sphinx to work:
 source_suffix = '.rst'
 master_doc = 'index'
-author = u'Erik Rose'
+author = 'Erik Rose'
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 root_for_relative_js_paths = './'

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,9 @@ deps =
 allowlist_externals =
     env
     npm
-commands_pre = npm install --no-save jsdoc@4.0.0 typedoc@0.15.0
+commands_pre =
+    npm install --no-save jsdoc@4.0.4 typedoc@0.15.0
+    npm list --all
 # Contrary to the tox docs, setenv's changes to $PATH are not visible inside
 # any commands we call. I hack around this with env:
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,6 @@ allowlist_externals =
     npm
 commands_pre =
     npm install --no-save jsdoc@4.0.4 typedoc@0.15.0
-    npm list --all
 # Contrary to the tox docs, setenv's changes to $PATH are not visible inside
 # any commands we call. I hack around this with env:
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 envlist =
-    py{38,39,310,311}-sphinx5
-    py{38,39,310,311}-sphinx6
-    py{38,39,310,311}-sphinx7
+    py{39,310,311}-sphinx5
+    py{39,310,311}-sphinx6
+    py{39,310,311}-sphinx7
 
 [gh-actions]
 python =
-  3.8: py38
   3.9: py39
   3.10: py310
   3.11: py311


### PR DESCRIPTION
I needed to figure out if CI worked, so I did a cosmetic fix to the `ci.yml` file.

That unearthed some problem with linkify-it or markdown-it. Updating jsdoc from 4.0.0 to 4.0.4 got those tests passing, but only for Python 3.8.

We want to drop support for Python 3.8 anyhow, so I dropped that now so that all the environments are failing the same way. But that didn't pan out as I had hoped.

Turns out Sphinx v7.3.0 includes a cosmetic change that's not in the changelog that drops the `" --"` from param lists if there's no param description. I added explicit handling for that.

That gets CI working again.