### PR TITLE
Add support for Sphinx 8.x.x

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
 envlist =
-    # sphinx 5.3.0 support python 3.6 through 3.11
+    # sphinx 5.3.0 supports python 3.6 through 3.11
     py{39,310,311}-sphinx5
     # sphinx 6.2.1 supports python 3.8 through 3.11
     py{39,310,311}-sphinx6
-    # sphinx 7.4.7 support python 3.9 through 3.13
+    # sphinx 7.4.7 supports python 3.9 through 3.13
     py{39,310,311,312,313}-sphinx7
+    # sphinx 8.1.3 support python 3.10 through 3.13
+    py{310,311,312,313}-sphinx8
 
 [gh-actions]
 python =
@@ -23,6 +25,7 @@ deps =
     sphinx5: sphinx<6.0.0
     sphinx6: sphinx<7.0.0
     sphinx7: sphinx<8.0.0
+    sphinx8: sphinx<9.0.0
 allowlist_externals =
     env
     npm


### PR DESCRIPTION
Sphinx 8 deprecated a couple of things and we see warnings now in the tests:

```
tests/conftest.py:2
  /home/willkg/mozilla/sphinx-js/tests/conftest.py:2: RemovedInSphinx90Warning: 'sphinx.testing.path' is deprecated. Use 'os.path' or 'pathlib' instead.
    from sphinx.testing.path import path

tests/test_incremental.py:8
  /home/willkg/mozilla/sphinx-js/tests/test_incremental.py:8: RemovedInSphinx90Warning: The alias 'sphinx.testing.util.strip_escseq' is deprecated, use 'sphinx.util.console.strip_colors' instead. Check CHANGES for Sphinx API modifications.
    from sphinx.testing.util import strip_escseq
```

I'm deprecating the project and don't plan to add support for Sphinx 9.x.x, so this is fine for now.