### PR TITLE
Improve handling of docs from third-party libraries

### DIFF
--- a/sphinx_js/js/convertTopLevel.ts
+++ b/sphinx_js/js/convertTopLevel.ts
@@ -254,13 +254,19 @@ class PathComputer implements ReflectionVisitor {
  */
 function renderCommentContent(content: CommentDisplayPart[]): Description {
   return content.map((x): DescriptionItem => {
-    if (x.kind === "code") {
-      return { type: "code", code: x.text };
+    switch (x.kind) {
+      case "code":
+        return { type: "code", code: x.text };
+      case "text":
+        return { type: "text", text: x.text };
+      // TODO: Add to DescriptionItem
+      case "inline-tag":
+        return { type: "text", text: x.text };
+      case "relative-link":
+        return { type: "text", text: x.text };
+      default:
+        throw new Error("Not implemented");
     }
-    if (x.kind === "text") {
-      return { type: "text", text: x.text };
-    }
-    throw new Error("Not implemented");
   });
 }
 

--- a/sphinx_js/js/redirectPrivateAliases.ts
+++ b/sphinx_js/js/redirectPrivateAliases.ts
@@ -167,7 +167,11 @@ export function redirectPrivateTypes(app: Application): ReadonlySymbolToType {
 
       const missing = discoverMissingExports(mod, context);
       for (const name of missing) {
-        const decl = name.declarations![0];
+        // Some symbols e.g. JSX.LibraryManagedAttributes have no declarations
+        if (!name.declarations || name.declarations.length === 0) {
+          continue;
+        }
+        const decl = name.declarations[0];
         if (decl.getSourceFile().fileName.includes("node_modules")) {
           continue;
         }


### PR DESCRIPTION
Hey, thanks for releasing a new version of the package!

I tried to use it to build Wagtail's docs, but unfortunately encountered a few errors that were raised during the build process due to third-party libraries that we use.

Here are a couple fixes I added to get the build working. Not sure how to write the tests though. Let me know if you'd like any changes!